### PR TITLE
Bold important Daylight Shavings Helmet buffs

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2021/Daylight Shavings Helmet.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Daylight Shavings Helmet.ash
@@ -41,6 +41,22 @@ int lastBeardIndex() {
 	return 0;
 }
 
+boolean isValuableBeard(string beardName) {
+	return listContainsValue(listMake(
+		"Spectacle Moustache",
+		"Toiletbrush Moustache",
+		"Gull-Wing Moustache",
+		"Friendly Chops",
+		"Surrealist's Moustache"
+	), beardName);
+}
+
+buffer boldIfValuable(string beardName) {
+	return isValuableBeard(beardName) ?
+		HTMLGenerateSpanOfClass(beardName, "r_bold") :
+		to_buffer(beardName);
+}
+
 RegisterTaskGenerationFunction("IOTMDaylightShavingsHelmetGenerateTasks");
 void IOTMDaylightShavingsHelmetGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
 {
@@ -60,9 +76,9 @@ void IOTMDaylightShavingsHelmetGenerateTasks(ChecklistEntry [int] task_entries, 
 	string nextBeardBuffEffect;
 	foreach nextBeardBuffName in nextBeardBuff {
 		nextBeardBuffDescription = nextBeardBuff[nextBeardBuffName];
-		nextBeardBuffEffect = nextBeardBuffName + ", " + nextBeardBuffDescription;
+		nextBeardBuffEffect = boldIfValuable(nextBeardBuffName) + ", " + to_buffer(nextBeardBuffDescription);
 	}
-	description.listAppend(HTMLGenerateSpanOfClass("Next shavings effect: ", "r_bold") + nextBeardBuffEffect);
+	description.listAppend("Next shavings effect: <br>" + nextBeardBuffEffect);
 
 	string [int][int] tooltip_table;
 	for i from lastBeardIndex() + 1 to lastBeardIndex() + 11 {
@@ -70,7 +86,7 @@ void IOTMDaylightShavingsHelmetGenerateTasks(ChecklistEntry [int] task_entries, 
 		string buffDescription;
 		foreach buffName in buff {
 			buffDescription = buff[buffName];
-			tooltip_table.listAppend(listMake(buffName, buffDescription));
+			tooltip_table.listAppend(listMake(boldIfValuable(buffName), buffDescription));
 		}
 	}
 


### PR DESCRIPTION
At TES's request, started highlighting important buffs with bold, and tweaked the display of next effect so the label + buff weren't both bold.

<img width="358" alt="Screen Shot 2022-11-11 at 8 33 31 PM" src="https://user-images.githubusercontent.com/481668/201451836-50eb3990-c0b8-4ea2-9f82-0f70bfe81f29.png">

<img width="477" alt="Screen Shot 2022-11-11 at 9 01 25 PM" src="https://user-images.githubusercontent.com/481668/201451856-73fbfefc-3766-4d04-9342-fe6787cdb6b5.png">
