### PR TITLE
Add model train tile

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
@@ -1,4 +1,4 @@
-string [string, string] carDescriptions;
+string [string, string] stationDescriptions;
 
 int trainSetReconfigurableIn() {
     int trainPosition = get_property_int("trainsetPosition");
@@ -63,8 +63,7 @@ void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, Checklist
 
     int trainPosition = get_property_int("trainsetPosition");
     int whenTrainsetWasConfigured = get_property_int("lastTrainsetConfiguration");
-    string trainCars = get_property("trainsetConfiguration");
-    string[int] splitTrain = split_string(trainCars, ",");
+    string[int] stations = split_string(get_property("trainsetConfiguration"), ",");
 
     if (oreConfiguredWhenNotNeeded()) {
         description.listAppend(HTMLGenerateSpanFont("Have ore configured when it's not needed!", "red"));
@@ -88,16 +87,16 @@ void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, Checklist
         description.listAppend("Train set reconfigurable in " + HTMLGenerateSpanOfClass(reconfigurableIn.to_string() + " combats.", "r_bold"));
     }
 
-    string[string] nextTrainCar = carDescriptions[splitTrain[trainPosition % 8]];
-    description.listAppend("Next car: " + HTMLGenerateSpanOfClass(nextTrainCar["name"], "r_bold") + " - " + nextTrainCar["description"]);
+    string[string] nextStation = stationDescriptions[stations[trainPosition % 8]];
+    description.listAppend("Next station: " + HTMLGenerateSpanOfClass(nextStation["name"], "r_bold") + " - " + nextStation["description"]);
 
     string [int][int] tooltipTable;
     for i from trainPosition to trainPosition + 7 {
-		string[string] car = carDescriptions[splitTrain[i % 8]];
-		tooltipTable.listAppend(listMake(HTMLGenerateSpanOfClass(car["name"], "r_bold"), car["description"]));
+		string[string] station = stationDescriptions[stations[i % 8]];
+		tooltipTable.listAppend(listMake(HTMLGenerateSpanOfClass(station["name"], "r_bold"), station["description"]));
 	}
     buffer tooltipText;
-    tooltipText.append(HTMLGenerateTagWrap("div", "Train car cycle", mapMake("class", "r_bold r_centre", "style", "padding-bottom:0.25em;")));
+    tooltipText.append(HTMLGenerateTagWrap("div", "Train station cycle", mapMake("class", "r_bold r_centre", "style", "padding-bottom:0.25em;")));
 	tooltipText.append(HTMLGenerateSimpleTableLines(tooltipTable));
     string trainCycleList = HTMLGenerateSpanOfClass(HTMLGenerateSpanOfClass(tooltipText, "r_tooltip_inner_class r_tooltip_inner_class_margin") + "Full train cycle", "r_tooltip_outer_class");
 	description.listAppend(trainCycleList);
@@ -113,13 +112,13 @@ void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, Checklist
     whereToAddTile.listAppend(ChecklistEntryMake("__item toy crazy train", url, ChecklistSubentryMake(main_title, description), priority).ChecklistEntrySetIDTag("Model train set"));
 }
 
-carDescriptions = {
+stationDescriptions = {
     "unknown": {
         "name": "Unknown",
-        "description": "We don't recognize that train car!",
+        "description": "We don't recognize that train station!",
     },
     "empty": {
-        "name": "Empty",
+        "name": "Empty station",
         "description": HTMLGenerateSpanFont("Train set isn't fully configured!", "red"),
     },
     "meat_mine": {

--- a/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
@@ -1,0 +1,141 @@
+string [string, string] carDescriptions;
+
+int trainSetReconfigurableIn() {
+    int trainPosition = get_property_int("trainsetPosition");
+    int whenTrainsetWasConfigured = get_property_int("lastTrainsetConfiguration");
+    if (whenTrainsetWasConfigured == trainPosition ||
+        trainPosition - whenTrainsetWasConfigured >= 40) {
+        return 0;
+    } else {
+        return 40 - (trainPosition - whenTrainsetWasConfigured);
+    }
+}
+
+RegisterTaskGenerationFunction("IOTMModelTrainSetGenerateTasks");
+void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+    if (!__iotms_usable[lookupItem("model train set")]) return;
+
+    string url = "campground.php?action=workshed";
+    string [int] description;
+    string main_title = "Model train set progress";
+
+    int trainPosition = get_property_int("trainsetPosition");
+    int whenTrainsetWasConfigured = get_property_int("lastTrainsetConfiguration");
+    string trainCars = get_property("trainsetConfiguration");
+    string[int] splitTrain = split_string(trainCars, ",");
+
+    int reconfigurableIn = trainSetReconfigurableIn();
+    if (reconfigurableIn == 0)
+    {
+        description.listAppend("Train set reconfigurable!");
+    }
+    else {
+        description.listAppend("Train set reconfigurable in " + HTMLGenerateSpanOfClass(reconfigurableIn.to_string() + " combats.", "r_bold"));
+    }
+
+    string[string] nextTrainCar = carDescriptions[splitTrain[trainPosition % 8]];
+    description.listAppend("Next car: " + HTMLGenerateSpanOfClass(nextTrainCar["name"], "r_bold") + " - " + nextTrainCar["description"]);
+
+    string [int][int] tooltipTable;
+    for i from trainPosition to trainPosition + 7 {
+		string[string] car = carDescriptions[splitTrain[i % 8]];
+		tooltipTable.listAppend(listMake(HTMLGenerateSpanOfClass(car["name"], "r_bold"), car["description"]));
+	}
+    buffer tooltipText;
+    tooltipText.append(HTMLGenerateTagWrap("div", "Train car cycle", mapMake("class", "r_bold r_centre", "style", "padding-bottom:0.25em;")));
+	tooltipText.append(HTMLGenerateSimpleTableLines(tooltipTable));
+    string trainCycleList = HTMLGenerateSpanOfClass(HTMLGenerateSpanOfClass(tooltipText, "r_tooltip_inner_class r_tooltip_inner_class_margin") + "Full train cycle", "r_tooltip_outer_class");
+	description.listAppend(trainCycleList);
+    
+    ChecklistEntry[int] whereToAddIt;
+
+    optional_task_entries.listAppend(ChecklistEntryMake("__item toy crazy train", url, ChecklistSubentryMake(main_title, description), 8).ChecklistEntrySetIDTag("Model train set"));
+}
+
+carDescriptions = {
+    "unknown": {
+        "name": "Unknown",
+        "description": "We don't recognize that train car!",
+    },
+    "empty": {
+        "name": "Empty",
+        "description": HTMLGenerateSpanFont("Train set isn't fully configured!", "red"),
+    },
+    "meat_mine": {
+        "name": "Meat Mine",
+        "description": "Bonus meat",
+    },
+    "tower_fizzy": {
+        "name": "Fizzy Tower",
+        "description": "MP regen",
+    },
+    "viewing_platform": {
+        "name": "Viewing Platform",
+        "description": "Gain extra stats",
+    },
+    "tower_frozen": {
+        "name": "Frozen Tower",
+        "description": HTMLGenerateSpanFont("Hot", "red") + " res, " + HTMLGenerateSpanFont("Cold", "blue") + " dmg",
+    },
+    "spooky_graveyard": {
+        "name": "Spooky Graveyard",
+        "description": HTMLGenerateSpanFont("Stench", "green") + " res, " + HTMLGenerateSpanFont("Spooky", "grey") + " dmg",
+    },
+    "logging_mill": {
+        "name": "Logging Mill",
+        "description": "Bridge parts or stats",
+    },
+    "candy_factory": {
+        "name": "Candy Factory",
+        "description": "Pick up random candy",
+    },
+    "coal_hopper": {
+        "name": "Coal Hopper",
+        "description": "Double power of next station",
+    },
+    "tower_sewage": {
+        "name": "Sewage Tower",
+        "description": HTMLGenerateSpanFont("Cold", "blue") + " res, " + HTMLGenerateSpanFont("Stench", "green") + " dmg",
+    },
+    "oil_refinery": {
+        "name": "Oil Refinery",
+        "description": HTMLGenerateSpanFont("Spooky", "grey") + " res, " + HTMLGenerateSpanFont("Sleaze", "purple") + " dmg",
+    },
+    "oil_bridge": {
+        "name": "Oil Bridge",
+        "description": HTMLGenerateSpanFont("Sleaze", "purple") + " res, " + HTMLGenerateSpanFont("Hot", "red") + " dmg",
+    },
+    "water_bridge": {
+        "name": "Bridge Over Troubled Water",
+        "description": "Increase ML",
+    },
+    "groin_silo": {
+        "name": "Groin Silo",
+        "description": "Gain moxie",
+    },
+    "grain_silo": {
+        "name": "Grain Silo",
+        "description": "Get base booze",
+    },
+    "brain_silo": {
+        "name": "Brain Silo",
+        "description": "Gain mysticality",
+    },
+    "brawn_silo": {
+        "name": "Brawn Silo",
+        "description": "Gain muscle",
+    },
+    "prawn_silo": {
+        "name": "Prawn Silo",
+        "description": "Acquire more food",
+    },
+    "trackside_diner": {
+        "name": "Trackside Diner",
+        "description": "Serves the last food you found",
+    },
+    "ore_hopper": {
+        "name": "Ore Hopper",
+        "description": "Get some ore",
+    }
+};

--- a/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
@@ -48,7 +48,8 @@ boolean shouldNag() {
     return trainSetReconfigurableIn() == 0 &&
         (oreConfiguredWhenNotNeeded() ||
         loggingMillConfiguredWhenNotNeeded() ||
-        statsConfiguredWhenNotNeeded());
+        statsConfiguredWhenNotNeeded() ||
+        stationConfigured("empty"));
 }
 
 RegisterTaskGenerationFunction("IOTMModelTrainSetGenerateTasks");
@@ -73,6 +74,9 @@ void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, Checklist
     }
     if (statsConfiguredWhenNotNeeded()) {
         description.listAppend(HTMLGenerateSpanFont("Have stats configured when they're not needed!", "red"));
+    }
+    if (stationConfigured("empty")) {
+        description.listAppend(HTMLGenerateSpanFont("Have an empty station configured!", "red"));
     }
 
     int reconfigurableIn = trainSetReconfigurableIn();

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -127,3 +127,4 @@ import "relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash";
 import "relay/TourGuide/Items of the Month/2022/Jurassic Parka.ash";
 import "relay/TourGuide/Items of the Month/2022/Autumnaton.ash";
 import "relay/TourGuide/Items of the Month/2022/Cookbookbat.ash";
+import "relay/TourGuide/Items of the Month/2022/Model Train Set.ash";

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -24,6 +24,8 @@ void initialiseIOTMsUsable()
             __iotms_usable[lookupItem("diabolic pizza cube")] = true;
         if (__campground[lookupItem("cold medicine cabinet")] > 0)
             __iotms_usable[lookupItem("cold medicine cabinet")] = true;
+        if (__campground[lookupItem("model train set")] > 0)
+            __iotms_usable[lookupItem("model train set")] = true;
 
         // Garden
         if (__campground[lookupItem("packet of mushroom spores")] > 0)


### PR DESCRIPTION
* Displays how long until train set will be configurable again
* Displays next train station
* Includes a table with all stations in order
* Detects potential misconfigurations (ore/lumber/stats when not needed, empty stations)
* Placed in optional tasks near fallbot, CMG, etc by default, but jumps to high priority task if a misconfiguration is detected and the train set is currently re-configurable

<img width="346" alt="Normal screenshot" src="https://user-images.githubusercontent.com/481668/211134242-fa529e2d-c844-4d1d-bbd6-49f0e23f7730.png">

<img width="390" alt="Screenshot with logging mill misconfiguration" src="https://user-images.githubusercontent.com/481668/211134247-570bcc0a-e57d-4691-ab29-715a670ea6ac.png">

<img width="310" alt="Full train cycle screenshot" src="https://user-images.githubusercontent.com/481668/211134294-7d228aba-a0ba-465f-9fd7-61028460fc97.png">

