### PR TITLE
Update Sets/Tiles for Community Service

### DIFF
--- a/Source/relay/TourGuide/Sets/8-bit Realm.ash
+++ b/Source/relay/TourGuide/Sets/8-bit Realm.ash
@@ -66,7 +66,7 @@ void S8bitRealmGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
         optional_task_entries.listAppend(ChecklistEntryMake("__item digital key", active_url, ChecklistSubentryMake(title, modifiers, description), $locations[fear man's level]).ChecklistEntrySetIDTag("Angry jung man familiar digital key psycho jar use"));
         need_route_output = false;
     }
-    if (my_path().id == PATH_EXPLOSIONS) need_route_output = false;
+    if (my_path().id == PATH_EXPLOSIONS || my_path().id == PATH_COMMUNITY_SERVICE) need_route_output = false;
     if (need_route_output)
     {
         if (in_hardcore() || !$item[jar of psychoses (The Crackpot Mystic)].is_unrestricted() || !$item[jar of psychoses (The Crackpot Mystic)].item_is_usable())

--- a/Source/relay/TourGuide/Sets/Area Unlocks.ash
+++ b/Source/relay/TourGuide/Sets/Area Unlocks.ash
@@ -16,7 +16,7 @@ void SAreaUnlocksGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry
         }
         if (my_path().id == PATH_NUCLEAR_AUTUMN)
         {
-            subentry.entries.listAppend("Wait until level eleven, which will unlock it autumnaically.");
+            subentry.entries.listAppend("Wait until level eleven, which will unlock it autumn-atically.");
         }
 		else if (!knoll_available())
 		{

--- a/Source/relay/TourGuide/Sets/Daily Dungeon.ash
+++ b/Source/relay/TourGuide/Sets/Daily Dungeon.ash
@@ -74,6 +74,9 @@ void SDailyDungeonGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntr
     int skeleton_key_amount = $item[skeleton key].available_amount() + $item[skeleton key].creatable_amount();
     boolean avoid_using_skeleton_key = ($item[Platinum Yendorian Express Card].available_amount() == 0 && $item[pick-o-matic lockpicks].available_amount() == 0 && (skeleton_key_amount) <= 2 && skeleton_key_amount > 0 && !__quest_state["Level 13"].state_boolean["Past keys"] && in_ronin());
 	
+	if (my_path().id == PATH_COMMUNITY_SERVICE) 
+		need_to_do_daily_dungeon = false;
+
 	boolean delay_daily_dungeon = false;
 	string delay_daily_dungeon_reason = "";
 	if (need_to_do_daily_dungeon)
@@ -151,6 +154,10 @@ void SDailyDungeonGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntr
     
     if (get_property_int("_lastDailyDungeonRoom") > 0)
         need_to_do_daily_dungeon = true;
+
+	if (my_path().id == PATH_COMMUNITY_SERVICE) 
+		need_to_do_daily_dungeon = false;
+
 	if (need_to_do_daily_dungeon && !get_property_boolean("dailyDungeonDone"))
 	{
 		if (delay_daily_dungeon)

--- a/Source/relay/TourGuide/Sets/Hole in the Sky.ash
+++ b/Source/relay/TourGuide/Sets/Hole in the Sky.ash
@@ -9,6 +9,8 @@ boolean HITSStillRelevant()
 		return false;
 	if (!__quest_state["Level 10"].finished && my_path().id != PATH_EXPLOSIONS)
 		return false;
+    if (my_path().id == PATH_COMMUNITY_SERVICE)
+        return false;
         
 	return true;
 }

--- a/Source/relay/TourGuide/Sets/Misc Items.ash
+++ b/Source/relay/TourGuide/Sets/Misc Items.ash
@@ -997,7 +997,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
         resource_entries.listAppend(ChecklistEntryMake("__item BittyCar MeatCar", "inventory.php?ftext=bittycar", ChecklistSubentryMake("BittyCar " + available_items.listJoinComponents(", ", "or") + " usable", "", description), importance_level_unimportant_item).ChecklistEntrySetIDTag("Bittycars resource"));
     }
     
-    if (in_run && !__quest_state["Level 13"].state_boolean["Stat race completed"] && __quest_state["Level 13"].state_string["Stat race type"] != "mysticality" && !get_property_ascension("lastGoofballBuy") && __quest_state["Level 3"].started && my_path().id != PATH_ZOMBIE_SLAYER) {
+    if (in_run && !__quest_state["Level 13"].state_boolean["Stat race completed"] && __quest_state["Level 13"].state_string["Stat race type"] != "mysticality" && !get_property_ascension("lastGoofballBuy") && __quest_state["Level 3"].started && my_path().id != PATH_ZOMBIE_SLAYER && my_path().id != PATH_COMMUNITY_SERVICE) {
         resource_entries.listAppend(ChecklistEntryMake("__item bottle of goofballs", "tavern.php?place=susguy", ChecklistSubentryMake("Bottle of goofballs obtainable", "", "For the lair stat test.|Costs nothing, but be careful..."), importance_level_unimportant_item).ChecklistEntrySetIDTag("Goofballs resource"));
     }
     

--- a/Source/relay/TourGuide/Sets/Skills.ash
+++ b/Source/relay/TourGuide/Sets/Skills.ash
@@ -249,7 +249,7 @@ void SSkillsGenerateResource(ChecklistEntry [int] resource_entries)
     if (lookupSkill("Evoke Eldritch Horror").skill_is_usable() && !get_property_boolean("_eldritchHorrorEvoked")) {
         resource_entries.listAppend(ChecklistEntryMake("__skill Evoke Eldritch Horror", "skillz.php", ChecklistSubentryMake("Evoke Eldritch Horror", "", "Free fight."), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Evoke eldritch horror skill free fight"));
     }
-    if (!get_property_boolean("_eldritchTentacleFought") && my_path().id != PATH_EXPLOSIONS) {
+    if (!get_property_boolean("_eldritchTentacleFought") && my_path().id != PATH_EXPLOSIONS && my_path().id != PATH_COMMUNITY_SERVICE) {
         resource_entries.listAppend(ChecklistEntryMake("__skill Evoke Eldritch Horror", "place.php?whichplace=forestvillage", ChecklistSubentryMake("Science Tent Tentacle", "", "Free fight."), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Daily forest tentacle free fight"));
     }
     


### PR DESCRIPTION
Updates for Community Service only:
- Removes Continuum Transfunctioner tile
- Removes Daily Dungeon reminder tile
- Removes Gelatinous Cubeling reminder tile
- Does not recommend free Goofballs (can't get there)
- Does not recommend free science tentacle fight (Summon skill free fight remains)

Other:
- Tried to fix a random spelling error on a joke from years ago - "autumnaically" -> "autumn-atically"