### PR TITLE
big january update w/ tons of TES changes

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2010/Crown of Thrones.ash
+++ b/Source/relay/TourGuide/Items of the Month/2010/Crown of Thrones.ash
@@ -1,75 +1,3 @@
-Record COTSuggestion
-{
-    string reason;
-    familiar [int] familiars;
-};
-
-
-COTSuggestion COTSuggestionMake(string reason, familiar [int] familiars)
-{
-    COTSuggestion suggestion;
-    suggestion.reason = reason;
-    suggestion.familiars = familiars;
-    
-    return suggestion;
-}
-
-COTSuggestion COTSuggestionMake(string reason, familiar f)
-{
-    familiar [int] familiar_list;
-    familiar_list.listAppend(f);
-    return COTSuggestionMake(reason, familiar_list);
-}
-
-COTSuggestion COTSuggestionMake(string reason, boolean [familiar] familiars_in)
-{
-    familiar [int] familiars_out;
-    foreach f in familiars_in
-        familiars_out.listAppend(f);
-    return COTSuggestionMake(reason, familiars_out);
-}
-
-void listAppend(COTSuggestion [int] list, COTSuggestion entry)
-{
-	int position = list.count();
-	while (list contains position)
-		position += 1;
-	list[position] = entry;
-}
-
-
-//Follows in order. If we can't find one in the first set, we check the second, then third, etc.
-//This allows for supporting +25% meat, then falling back on +20%, etc.
-Record COTSuggestionSet
-{
-    COTSuggestion [int] suggestions;
-};
-
-COTSuggestionSet COTSuggestionSetMake(COTSuggestion [int] suggestions)
-{
-    COTSuggestionSet suggestion_set;
-    suggestion_set.suggestions = suggestions;
-    
-    return suggestion_set;
-}
-
-COTSuggestionSet COTSuggestionSetMake(COTSuggestion suggestion)
-{
-    COTSuggestionSet suggestion_set;
-    suggestion_set.suggestions.listAppend(suggestion);
-    
-    return suggestion_set;
-}
-
-void listAppend(COTSuggestionSet [int] list, COTSuggestionSet entry)
-{
-	int position = list.count();
-	while (list contains position)
-		position += 1;
-	list[position] = entry;
-}
-
-
 void IOTMCOTGenerateSuggestions(string [int] description)
 {
     familiar enthroned_familiar = my_enthroned_familiar();
@@ -233,6 +161,50 @@ void IOTMCOTGenerateResource(ChecklistEntry [int] resource_entries)
         return;
     string [int] description;
     
+    void addFamiliarDropsLine(string fam, string prop, int limit, string dropdesc) {
+        int currentDrops = get_property_int(prop);
+        familiar thisFam = fam.to_familiar();
+        if    ( !thisFam.have_familiar() ) { return; }
+        string txtclr = "";
+        if    ( fam.index_of("Stomping") > -1 ) {
+            txtclr = (get_property_boolean("bootsCharged"))?"blue":"black";
+        }
+        if    ( currentDrops == limit ) { txtclr = "gray"; }
+        
+        description.listAppend(HTMLGenerateSpanFont(fam+": "+currentDrops + "/"+limit+" "+dropdesc+".", txtclr));
+        return;
+    }
+    
+    description.listAppend(HTMLGenerateSpanFont("Crown/Bjorn-specific drops", "purple"));
+    addFamiliarDropsLine("Garbage Fire", "_garbageFireDropsCrown", 3, "burning newspapers");
+	addFamiliarDropsLine("Grim Brother", "_grimFairyTaleDropsCrown", 2, "grim fairy tales");
+	addFamiliarDropsLine("Grimstone Golem", "_grimstoneMaskDropsCrown", 1, "grimstone mask");
+	addFamiliarDropsLine("Machine Elf", "_abstractionDropsCrown", 25, "abstractions");
+    addFamiliarDropsLine("Optimistic Candle", "_optimisticCandleDropsCrown", 3, "globs of melted wax");
+	addFamiliarDropsLine("Ms. Puck Man", "_yellowPixelDropsCrown", 25, "yellow pixels");
+	addFamiliarDropsLine("Puck Man", "_yellowPixelDropsCrown", 25, "yellow pixels");
+	addFamiliarDropsLine("Trick-or-Treating Tot", "_hoardedCandyDropsCrown", 3, "hoarded candy wads");
+	
+    description.listAppend(HTMLGenerateSpanFont("General familiar drops", "purple"));
+    addFamiliarDropsLine("Adventurous Spelunker", "_spelunkingTalesDrops", 1, "Tales of Spelunking");
+	addFamiliarDropsLine("Astral Badger", "_astralDrops", 5, "astral mushrooms");
+	addFamiliarDropsLine("Baby Sandworm", "_aguaDrops", 5, "Agua de Vidae");
+	addFamiliarDropsLine("Blavious Kloop", "_kloopDrops", 5, "devlish folios");
+	addFamiliarDropsLine("Bloovian Groose", "_grooseDrops", 5, "groose grease");
+	addFamiliarDropsLine("Cat Burglar", "_catBurglarCharge", 30, "Heist charges");
+	#addFamiliarDropsLine("Cookbookbat", "_turkeyBooze", 5, "Turkey booze");
+	addFamiliarDropsLine("Fist Turkey", "_turkeyBooze", 5, "Turkey booze");
+	addFamiliarDropsLine("Galloping Grill", "_hotAshesDrops", 5, "hot ashes");
+    addFamiliarDropsLine("Golden Monkey", "_powderedGoldDrops", 5, "powdered gold");
+    addFamiliarDropsLine("Green Pixie", "_absintheDrops", 5, "bottles of absinthe");
+	addFamiliarDropsLine("Grim Brother", "_grimFairyTaleDrops", 5, "grim fairy tales");
+	addFamiliarDropsLine("Li'l Xenomorph", "_transponderDrops", 5, "transponders");
+	addFamiliarDropsLine("Llama Lama", "_gongDrops", 5, "Llama gongs");
+	addFamiliarDropsLine("Puck Man", "_powerPillDrops", 11, "power pills");
+    addFamiliarDropsLine("Ms. Puck Man", "_powerPillDrops", 11, "power pills");
+    addFamiliarDropsLine("Rogue Program", "_tokenDrops", 5, "GG tokens");
+    addFamiliarDropsLine("Stomping Boots", "_pasteDrops", 7, "spleen pastes");
+    addFamiliarDropsLine("Unconscious Collective", "_dreamJarDrops", 5, "dream jars");
     item crown_item = $item[crown of thrones];
     if (crown_item.equipped_amount() == 0 && $item[Buddy Bjorn].available_amount() > 0)
         crown_item = $item[Buddy Bjorn];

--- a/Source/relay/TourGuide/Items of the Month/2010/Crown of Thrones.ash
+++ b/Source/relay/TourGuide/Items of the Month/2010/Crown of Thrones.ash
@@ -1,3 +1,75 @@
+Record COTSuggestion
+{
+    string reason;
+    familiar [int] familiars;
+};
+
+
+COTSuggestion COTSuggestionMake(string reason, familiar [int] familiars)
+{
+    COTSuggestion suggestion;
+    suggestion.reason = reason;
+    suggestion.familiars = familiars;
+    
+    return suggestion;
+}
+
+COTSuggestion COTSuggestionMake(string reason, familiar f)
+{
+    familiar [int] familiar_list;
+    familiar_list.listAppend(f);
+    return COTSuggestionMake(reason, familiar_list);
+}
+
+COTSuggestion COTSuggestionMake(string reason, boolean [familiar] familiars_in)
+{
+    familiar [int] familiars_out;
+    foreach f in familiars_in
+        familiars_out.listAppend(f);
+    return COTSuggestionMake(reason, familiars_out);
+}
+
+void listAppend(COTSuggestion [int] list, COTSuggestion entry)
+{
+	int position = list.count();
+	while (list contains position)
+		position += 1;
+	list[position] = entry;
+}
+
+
+//Follows in order. If we can't find one in the first set, we check the second, then third, etc.
+//This allows for supporting +25% meat, then falling back on +20%, etc.
+Record COTSuggestionSet
+{
+    COTSuggestion [int] suggestions;
+};
+
+COTSuggestionSet COTSuggestionSetMake(COTSuggestion [int] suggestions)
+{
+    COTSuggestionSet suggestion_set;
+    suggestion_set.suggestions = suggestions;
+    
+    return suggestion_set;
+}
+
+COTSuggestionSet COTSuggestionSetMake(COTSuggestion suggestion)
+{
+    COTSuggestionSet suggestion_set;
+    suggestion_set.suggestions.listAppend(suggestion);
+    
+    return suggestion_set;
+}
+
+void listAppend(COTSuggestionSet [int] list, COTSuggestionSet entry)
+{
+	int position = list.count();
+	while (list contains position)
+		position += 1;
+	list[position] = entry;
+}
+
+
 void IOTMCOTGenerateSuggestions(string [int] description)
 {
     familiar enthroned_familiar = my_enthroned_familiar();

--- a/Source/relay/TourGuide/Items of the Month/2016/Protonic Accelerator Pack.ash
+++ b/Source/relay/TourGuide/Items of the Month/2016/Protonic Accelerator Pack.ash
@@ -3,6 +3,24 @@ import "relay/TourGuide/Support/Monster Data.ash";
 RegisterTaskGenerationFunction("IOTMProtonicAcceleratorPackGenerateTasks");
 void IOTMProtonicAcceleratorPackGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
 {
+    if (!$item[protonic accelerator pack].have()) return;
+	{	int nextGhostTurn = get_property_int("nextParanormalActivity");
+		int nextGhostTimer = (nextGhostTurn - total_turns_played());
+		string [int] description;
+		string url;
+		url = invSearch("protonic accelerator pack");
+		
+		if (nextGhostTurn <= total_turns_played())
+		{
+			description.listAppend(HTMLGenerateSpanFont("Who you gonna call? You!", "blue"));
+			if (!lookupItem("protonic accelerator pack").equipped())
+				description.listAppend(HTMLGenerateSpanFont("Equip the protopack first", "red"));
+			task_entries.listAppend(ChecklistEntryMake("__item protonic accelerator pack", url, ChecklistSubentryMake("It's ghost bustin' time!", "", description), -11));
+		}	
+		else
+			description.listAppend(nextGhostTimer + " adventures until your next protonic ghost.");
+			optional_task_entries.listAppend(ChecklistEntryMake("__item protonic accelerator pack", url, ChecklistSubentryMake("It's ghost bustin' time... eventually.", "", description), 8));
+	}	
     //Quest:
     if (QuestState("questPAGhost").in_progress || get_property("ghostLocation") != "")
     {

--- a/Source/relay/TourGuide/Items of the Month/2017/KGBriefcase.ash
+++ b/Source/relay/TourGuide/Items of the Month/2017/KGBriefcase.ash
@@ -13,8 +13,8 @@ void IOTMKGBriefcaseGenerateResource(ChecklistEntry [int] resource_entries)
         description.listAppend("Free run/banishes for twenty turns.|Use the KGB tranquilizer dart skill in-combat.");
         if (lookupItem("kremlin's greatest briefcase").equipped_amount() == 0)
         {
-            description.listAppend("Equip the briefcase first.");
-            //entry.url = "inventory.php?which=2";
+		    description.listAppend(HTMLGenerateSpanFont("Equip the briefcase first!", "red"));
+            url = "inventory.php?ftext=kremlin";
         }
         resource_entries.listAppend(ChecklistEntryMake("__item Kremlin's Greatest Briefcase", entry.url, ChecklistSubentryMake(pluralise(3 - get_property_int("_kgbTranquilizerDartUses"), "briefcase dart", "briefcase darts"), "", description)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Kremlin Briefcase tranq dart banish"));
     }

--- a/Source/relay/TourGuide/Items of the Month/2017/KGBriefcase.ash
+++ b/Source/relay/TourGuide/Items of the Month/2017/KGBriefcase.ash
@@ -14,7 +14,7 @@ void IOTMKGBriefcaseGenerateResource(ChecklistEntry [int] resource_entries)
         if (lookupItem("kremlin's greatest briefcase").equipped_amount() == 0)
         {
 		    description.listAppend(HTMLGenerateSpanFont("Equip the briefcase first!", "red"));
-            url = "inventory.php?ftext=kremlin";
+            entry.url = "inventory.php?ftext=kremlin";
         }
         resource_entries.listAppend(ChecklistEntryMake("__item Kremlin's Greatest Briefcase", entry.url, ChecklistSubentryMake(pluralise(3 - get_property_int("_kgbTranquilizerDartUses"), "briefcase dart", "briefcase darts"), "", description)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Kremlin Briefcase tranq dart banish"));
     }

--- a/Source/relay/TourGuide/Items of the Month/2019/Kramco Sausage-o-Matic.ash
+++ b/Source/relay/TourGuide/Items of the Month/2019/Kramco Sausage-o-Matic.ash
@@ -5,7 +5,7 @@ void IOTMKramcoSausageOMaticGenerateTasks(ChecklistEntry [int] task_entries, Che
     
     //If goblin is up, display reminder:
     KramcoSausageFightInformation fight_information = KramcoCalculateSausageFightInformation();
-    if (fight_information.turns_to_next_guaranteed_fight == 0 && my_path().id != PATH_LIVE_ASCEND_REPEAT && __misc_state["in run"])
+    if (fight_information.turns_to_next_guaranteed_fight == 0 && my_path_id() != PATH_LIVE_ASCEND_REPEAT && __misc_state["in run"])
     {
         
         string url = "";
@@ -29,7 +29,7 @@ void IOTMKramcoSausageOMaticGenerateTasks(ChecklistEntry [int] task_entries, Che
 RegisterResourceGenerationFunction("IOTMKramcoSausageOMaticGenerateResource");
 void IOTMKramcoSausageOMaticGenerateResource(ChecklistEntry [int] resource_entries)
 {
-    if (!lookupItem("Kramco Sausage-o-Matic&trade;").have() || my_path().id == PATH_LIVE_ASCEND_REPEAT) return;
+    if (!lookupItem("Kramco Sausage-o-Matic&trade;").have() || my_path_id() == PATH_LIVE_ASCEND_REPEAT) return;
 
     ChecklistEntry entry;
     entry.image_lookup_name = "__item Kramco Sausage-o-Matic&trade;";
@@ -46,14 +46,14 @@ void IOTMKramcoSausageOMaticGenerateResource(ChecklistEntry [int] resource_entri
         main_title = "Sausage goblin fight available";
         if (lookupItem("Kramco Sausage-o-Matic&trade;").equipped_amount() == 0) {
             main_description.listAppend(HTMLGenerateSpanFont("Equip the Kramco Sausage-o-Matic&trade; first.", "red"));
-            entry.url = "inventory.php?ftext=kramco+sausage-o-matic";
+            entry.url = "inventory.php?action=grind";
         }
     } else {
         main_title = round(fight_information.probability_of_sausage_fight * 100.0) + "% chance of sausage goblin this turn";
         main_description.listAppend(pluralise(fight_information.turns_to_next_guaranteed_fight, "turn", "turns") + " until next guaranteed goblin fight.");
         if (lookupItem("Kramco Sausage-o-Matic&trade;").equipped_amount() == 0) {
-            main_description.listAppend("Equip the Kramco Sausage-o-Matic&trade; first.");
-            entry.url = "inventory.php?ftext=kramco+sausage-o-matic";
+            main_description.listAppend(HTMLGenerateSpanFont("Equip the Kramco Sausage-o-Matic&trade; first.", "red"));
+            entry.url = "inventory.php?action=grind";
         }
     }
 
@@ -75,9 +75,15 @@ void IOTMKramcoSausageOMaticGenerateResource(ChecklistEntry [int] resource_entri
         int sausages_made = get_property_int("_sausagesMade");
         int meat_cost = 111 * (sausages_made + 1);
         sausage_description.listAppend("+1 adventure and +999 MP each.");
-        sausage_description.listAppend(sausage_casings + " casings available, " + sausages_eaten + "/23 eaten today.");
-        sausage_description.listAppend(pluralise(sausages_made, "sausage", "sausages") + " made; next costs " + meat_cost + " meat.");
-        
+        sausage_description.listAppend(HTMLGenerateSpanOfClass(sausage_casings, "r_bold") + " casings available, " + HTMLGenerateSpanOfClass(sausages_eaten + "/23", "r_bold") + " eaten today.");
+        if (sausages_made > 22)
+		{
+            sausage_description.listAppend(HTMLGenerateSpanFont(sausages_made + " sausages made today.", "purple"));
+        }	
+        else
+		{
+			sausage_description.listAppend(pluralise(sausages_made, "sausage", "sausages") + " made; next costs " + meat_cost + " meat.");
+		}
         entry.subentries.listAppend(ChecklistSubentryMake(pluralise(MIN(sausages_available, 23 - sausages_eaten), "magical sausage", "magical sausages") + " edible", "", sausage_description));
     }
     

--- a/Source/relay/TourGuide/Items of the Month/2019/Kramco Sausage-o-Matic.ash
+++ b/Source/relay/TourGuide/Items of the Month/2019/Kramco Sausage-o-Matic.ash
@@ -5,7 +5,7 @@ void IOTMKramcoSausageOMaticGenerateTasks(ChecklistEntry [int] task_entries, Che
     
     //If goblin is up, display reminder:
     KramcoSausageFightInformation fight_information = KramcoCalculateSausageFightInformation();
-    if (fight_information.turns_to_next_guaranteed_fight == 0 && my_path_id() != PATH_LIVE_ASCEND_REPEAT && __misc_state["in run"])
+    if (fight_information.turns_to_next_guaranteed_fight == 0 && my_path().id != PATH_LIVE_ASCEND_REPEAT && __misc_state["in run"])
     {
         
         string url = "";
@@ -29,7 +29,7 @@ void IOTMKramcoSausageOMaticGenerateTasks(ChecklistEntry [int] task_entries, Che
 RegisterResourceGenerationFunction("IOTMKramcoSausageOMaticGenerateResource");
 void IOTMKramcoSausageOMaticGenerateResource(ChecklistEntry [int] resource_entries)
 {
-    if (!lookupItem("Kramco Sausage-o-Matic&trade;").have() || my_path_id() == PATH_LIVE_ASCEND_REPEAT) return;
+    if (!lookupItem("Kramco Sausage-o-Matic&trade;").have() || my_path().id == PATH_LIVE_ASCEND_REPEAT) return;
 
     ChecklistEntry entry;
     entry.image_lookup_name = "__item Kramco Sausage-o-Matic&trade;";

--- a/Source/relay/TourGuide/Items of the Month/2019/Lil Doctor Bag.ash
+++ b/Source/relay/TourGuide/Items of the Month/2019/Lil Doctor Bag.ash
@@ -43,7 +43,8 @@ void IOTMLilDoctorBagGenerateResource(ChecklistEntry [int] resource_entries)
 	if (lookupItem("Lil' Doctor&trade; bag").available_amount() == 0) return;
 	//Otoscope: +200% item
     int otoscopes_left = clampi(3 - get_property_int("_otoscopeUsed"), 0, 3);
-    if (otoscopes_left > 0 && $skill[Otoscope].skill_is_usable() && __misc_state["in run"])
+    boolean otoscope_usable = my_path().id != PATH_G_LOVER && my_path().id != PATH_POCKET_FAMILIARS;
+    if (otoscopes_left > 0 && otoscope_usable && __misc_state["in run"])
     {
         string url;
         string [int] description;
@@ -54,13 +55,12 @@ void IOTMLilDoctorBagGenerateResource(ChecklistEntry [int] resource_entries)
             description.listAppend("Equip the Lil' Doctor™ bag first.");
             url = "inventory.php?ftext=lil'+doctor";
         }
-        //if (snojo_skill_entry.image_lookup_name == "")
-            //snojo_skill_entry.image_lookup_name = "__skill shattering punch";
         resource_entries.listAppend(ChecklistEntryMake("__item Lil' Doctor&trade; bag", url, ChecklistSubentryMake(pluralise(otoscopes_left, "otoscope", "otoscopes"), "", description), 8).ChecklistEntrySetIDTag("Lil doctor bag otoscope"));
     }
 	//Chest X-Ray: instakill
     int instakills_left = clampi(3 - get_property_int("_chestXRayUsed"), 0, 3);
-    if (instakills_left > 0 && $skill[Chest X-Ray].skill_is_usable())
+    boolean instakills_usable = my_path().id != PATH_G_LOVER && my_path().id != PATH_POCKET_FAMILIARS;
+    if (instakills_left > 0 && instakills_usable)
     {
     	string url;
         string [int] description;
@@ -69,22 +69,21 @@ void IOTMLilDoctorBagGenerateResource(ChecklistEntry [int] resource_entries)
         if (lookupItem("Lil' Doctor&trade; bag").equipped_amount() == 0)
         {
         	description.listAppend("Equip the Lil' Doctor™ bag first.");
-            url = "inventory.php?which=3";
+            url = "inventory.php?ftext=lil'+doctor";
         }
-        //if (snojo_skill_entry.image_lookup_name == "")
-            //snojo_skill_entry.image_lookup_name = "__skill shattering punch";
         resource_entries.listAppend(ChecklistEntryMake("__item Lil' Doctor&trade; bag", url, ChecklistSubentryMake(pluralise(instakills_left, "chest x-ray", "chest x-rays"), "", description), 0).ChecklistEntrySetCombinationTag("free instakill").ChecklistEntrySetIDTag("Lil doctor bag x-ray free kill"));
         
     }
 	//Reflex Hammer: Banish
     int banishes_left = clampi(3 - get_property_int("_reflexHammerUsed"), 0, 3);
-    if (banishes_left > 0 && $skill[Reflex Hammer].skill_is_usable())
+    boolean banishes_usable = my_path().id != PATH_G_LOVER && my_path().id != PATH_POCKET_FAMILIARS;
+    if (banishes_left > 0 && banishes_usable)
     {
         string url;
         string [int] description;
         if (lookupItem("Lil' Doctor&trade; bag").equipped_amount() == 0) {
             description.listAppend(HTMLGenerateSpanFont("Equip the Lil' Doctor™ bag first", "red"));
-            url = "inventory.php?which=3";
+            url = "inventory.php?ftext=lil'+doctor";
         } else {
             description.listAppend("Free run/banish");
         }

--- a/Source/relay/TourGuide/Items of the Month/2019/Pocket Professor.ash
+++ b/Source/relay/TourGuide/Items of the Month/2019/Pocket Professor.ash
@@ -16,7 +16,7 @@ void IOTMPocketProfessorResource(ChecklistEntry [int] resource_entries)
         int nextLectureWeight = lecturesUsed ** 2 + 1;
         int nextLectureWeightChip = (lecturesUsed - 2) ** 2 + 1;
 
-        string main_title = (availableLectures > 0 ? pluralise(availableLectures, "lecture", "lectures") : "No lectures") + " available";
+        string main_title = (availableLectures > 0 ? pluralise(availableLectures, "lecture", "lectures") : "No lectures") + " available, " + lecturesUsed + " lectures used";
 
         // Subtitle
         string subtitle = "";

--- a/Source/relay/TourGuide/Items of the Month/2020/Box O Ghosts.ash
+++ b/Source/relay/TourGuide/Items of the Month/2020/Box O Ghosts.ash
@@ -3,8 +3,8 @@ RegisterTaskGenerationFunction("IOTMCommerceGhostGenerateTasks");
 void IOTMCommerceGhostGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
 {
 	item commerce_item = get_property_item("commerceGhostItem");
-	int commerce_statgain1 = my_level() * 20;
-	int commerce_statgain2 = my_level() * 25;
+	int commerce_statgain1 = (my_level() * 20) * (1.0 + numeric_modifier(my_primestat().to_string() + " Experience Percent") / 100.0);
+	int commerce_statgain2 = (my_level() * 25) * (1.0 + numeric_modifier(my_primestat().to_string() + " Experience Percent") / 100.0);
 	boolean in_grey_you = my_class() == $class[grey goo]; // Grey You gains zero stats from your commerce ghost.
 
 	if (__misc_state["in run"] && $familiar[Ghost of Crimbo Commerce].familiar_is_usable() && !in_grey_you)

--- a/Source/relay/TourGuide/Items of the Month/2020/Powerful Glove.ash
+++ b/Source/relay/TourGuide/Items of the Month/2020/Powerful Glove.ash
@@ -18,7 +18,7 @@ void IOTMPowerfulGloveGenerateResource(ChecklistEntry [int] resource_entries)
         description.listAppend(HTMLGenerateSpanOfClass("Replace Enemy (10% charge):", "r_bold") + " Swap monster.");
     description.listAppend(HTMLGenerateSpanOfClass("Shrink Enemy (5% charge):", "r_bold") + " Delevel.");
 
-    resource_entries.listAppend(ChecklistEntryMake("__item Powerful Glove", url, ChecklistSubentryMake(chargeLeft + "% battery charge", "", description)).ChecklistEntrySetIDTag("Powerful glove skills resource"));
+    resource_entries.listAppend(ChecklistEntryMake("__item Powerful Glove", url, ChecklistSubentryMake(chargeLeft + "% Powerful Glove battery charge", "", description)).ChecklistEntrySetIDTag("Powerful glove skills resource"));
 }
 
 RegisterTaskGenerationFunction("IOTMPowerfulGloveTask");

--- a/Source/relay/TourGuide/Items of the Month/2021/Cold Medicine Cabinet.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Cold Medicine Cabinet.ash
@@ -1,4 +1,3 @@
-//Cold Medicine Cabinet
 RegisterTaskGenerationFunction("IOTMColdMedicineCabinetGenerateTasks");
 void IOTMColdMedicineCabinetGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
 {
@@ -139,7 +138,13 @@ void IOTMColdMedicineCabinetGenerateResource(ChecklistEntry [int] resource_entri
 		string url = "campground.php?action=workshed";
 			
 		description.listAppend(HTMLGenerateSpanFont("Route turn-taking combats into the correct environments for a helpful spleen item!", "blue"));
-		
+		if (next_CMC_Turn > total_turns_played())
+		{
+			description.listAppend("" + HTMLGenerateSpanOfClass(next_CMC_Timer, "r_bold") + " adventures until your next consultation.");
+			description.listAppend("Spend " + HTMLGenerateSpanOfClass(next_CMC_Timer - 9, "r_bold") + " non-environmental adventures to double your pill.");
+			description.listAppend("" + HTMLGenerateSpanOfClass("Last 20 environments: ", "r_bold") + cmcCombatString + "");
+		}
+			
 		// Append the lil dot guy if it's useful.
 		if (length(dotMatrix) > 5) {
 			description.listAppend(dotMatrix);    

--- a/Source/relay/TourGuide/Items of the Month/2022/Cookbookbat.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Cookbookbat.ash
@@ -44,8 +44,14 @@ void IOTMCookbookbatGenerateResource(ChecklistEntry [int] resource_entries)
     buffer tooltip_text;
 	tooltip_text.append(HTMLGenerateTagWrap("div", "Cookbookbat Recipes!", mapMake("class", "r_bold r_centre", "style", "padding-bottom:0.25em;")));
 	tooltip_text.append(HTMLGenerateSimpleTableLines(pizzaParlorRecipes));
-			
+		
 	description.listAppend(HTMLGenerateSpanOfClass(HTMLGenerateSpanOfClass(tooltip_text, "r_tooltip_inner_class r_tooltip_inner_class_margin") + "Important Recipes", "r_tooltip_outer_class"));
 
+    int cookings_remaining = clampi(5 - get_property_int("_cookbookbatCrafting"), 0, 5);
+    if (cookings_remaining > 0) 
+    {
+        description.listAppend(HTMLGenerateSpanOfClass(cookings_remaining, "r_bold") + " free cooks: Unstable fulminate, potions, and more.");
+    }
+	
     resource_entries.listAppend(ChecklistEntryMake("__familiar cookbookbat", url, ChecklistSubentryMake("Pizza party with the Cookbookbat!", "", description)).ChecklistEntrySetIDTag("Cookbookbat Resource"));
 }

--- a/Source/relay/TourGuide/Quests/Airport.ash
+++ b/Source/relay/TourGuide/Quests/Airport.ash
@@ -304,7 +304,33 @@ void QSleazeAirportGenerateTasks(ChecklistEntry [int] task_entries)
     QSleazeAirportUMDGenerateTasks(task_entries);
 }
 
-//
+//Conspiracy Island Omega Button
+RegisterTaskGenerationFunction("IOTMConspiracyIslandGenerateTasks");
+void IOTMConspiracyIslandGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+    if (!__misc_state["spooky airport available"])
+        return;
+	//press the button!
+    ChecklistEntry entry;
+    entry.url = "place.php?whichplace=airport_spooky_bunker&action=si_controlpanel";
+    entry.image_lookup_name = "__item big red button";
+    entry.importance_level = 8;
+	int omegaPower = get_property_int("controlPanelOmega");
+	if (!get_property_boolean("_controlPanelUsed"))
+	{
+        entry.subentries.listAppend(ChecklistSubentryMake(omegaPower + "% Conspiracy Island Omega power", "", "At 100%, press Omega Button to reset better quests."));
+		if (!get_property_boolean("controlPanel8") == false)
+			entry.subentries.listAppend(ChecklistSubentryMake("", "", "Press 1912 Button."));
+		if (!get_property_boolean("controlPanel9") == false)
+			entry.subentries.listAppend(ChecklistSubentryMake("", "", "Press 0-0Z-E Button."));
+	}
+	if (omegaPower == 100)
+		entry.subentries.listAppend(ChecklistSubentryMake("100% power! Reset to gain new quests and then uze 0-0Z-E again!"));
+	if (entry.subentries.count() > 0)
+	{
+        optional_task_entries.listAppend(entry);
+	}
+}
 
 void QSpookyAirportJunglePunGenerateTasks(ChecklistEntry [int] task_entries)
 {

--- a/Source/relay/TourGuide/Quests/Level 11 - Desert.ash
+++ b/Source/relay/TourGuide/Quests/Level 11 - Desert.ash
@@ -60,6 +60,9 @@ void QLevel11DesertGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEnt
         exploration_per_turn += 1.0;
     if (my_path().id == PATH_LICENSE_TO_ADVENTURE && get_property_boolean("bondDesert"))
         exploration_per_turn += 2.0;
+    if ($item[survival knife].have() && __misc_state["can equip just about any weapon"] && $effect[ultrahydrated].have_effect() > 0) {
+        exploration_per_turn += 2.0;
+    }
     
     boolean have_blacklight_bulb = (my_path().id == PATH_AVATAR_OF_SNEAKY_PETE && get_property("peteMotorbikeHeadlight") == "Blacklight Bulb");
     if (have_blacklight_bulb)
@@ -81,6 +84,8 @@ void QLevel11DesertGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEnt
             description.listAppend("Adventure in the Oasis.");
             if ($items[11-leaf clover].available_amount() > 0)
                 description.listAppend("Potentially clover for 20 turns, versus 5.");
+            if (!get_property_boolean("fireExtinguisherDesertUsed") && !(available_amount($item[industrial fire extinguisher]) > 0) && get_property_int("_fireExtinguisherCharge") > 20)
+                description.listAppend("Or, use 20% fire extinguisher charge in the desert to drink the foam.");
             task_entries.listAppend(ChecklistEntryMake("__effect ultrahydrated", "place.php?whichplace=desertbeach", ChecklistSubentryMake("Acquire ultrahydrated effect", "", description), -11).ChecklistEntrySetIDTag("Council L11 quest desert ultrahydrated"));
         }
         //if (exploration > 0)
@@ -204,12 +209,20 @@ void QLevel11DesertGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEnt
             else
                 line_extra += "|Or bring along Melodramedary.";
         }
+		if ($item[survival knife].have() && ($item[survival knife].equipped_amount() == 0)) {
+			if (line == "")
+                line += "Equip your survival knife (only effective while Ultrahydrated)";
+            else
+                line_extra += "|Equip your survival knife (only effective while Ultrahydrated)";
+		}
         if (line != "") {
             if (should_output_compass_in_red)
                 line = HTMLGenerateSpanFont(line, "red");
             line += line_extra;
             subentry.entries.listAppend(line);
         }
-    }
+	 
+    } else
+        subentry.entries.listAppend("Could bring along Melodramedary.");
     task_entries.listAppend(ChecklistEntryMake(base_quest_state.image_name, url, subentry, $locations[the arid\, extra-dry desert,the oasis]).ChecklistEntrySetIDTag("Council L11 quest desert exploration"));
 }

--- a/Source/relay/TourGuide/Quests/Manor.ash
+++ b/Source/relay/TourGuide/Quests/Manor.ash
@@ -372,7 +372,7 @@ void QManorGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int]
         
         float drawers_per_turn = 1.0 + MAX(hot_resistance / 6.0, 0.0) + MAX(stench_resistance / 6.0, 0.0);
         
-        float drawers_needed = MAX(0, 21 - get_property_int("manorDrawerCount"));
+        int drawers_needed = MAX(0, 21 - get_property_int("manorDrawerCount"));
         
         int total_turns = ceil(drawers_needed / drawers_per_turn) + 1;
         
@@ -398,7 +398,7 @@ void QManorGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int]
                 }
             }
             
-            line += total_turns + " turns remaining.";
+            line += total_turns + " turns remaining, " + drawers_needed + " drawers remaining.";
             subentry.entries.listAppend(line);
         }
         

--- a/Source/relay/TourGuide/Sets/Misc Items.ash
+++ b/Source/relay/TourGuide/Sets/Misc Items.ash
@@ -634,6 +634,8 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
         int stinky_cheese_charge = min(100, get_property_int("_stinkyCheeseCount"));
         string title;
         string [int] description;
+		string url;
+		url = invSearch("stinky cheese");
         int importance = importance_level_item;
 
         if (stinky_cheese_charge < 100) {
@@ -648,7 +650,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
         }
         description.listAppend("Or some other stinky things.");
         
-        resource_entries.listAppend(ChecklistEntryMake("__item Ched", "", ChecklistSubentryMake(title, "", description), importance).ChecklistEntrySetIDTag("Stinky cheese resource"));
+        resource_entries.listAppend(ChecklistEntryMake("__item Ched", url, ChecklistSubentryMake(title, "", description), importance).ChecklistEntrySetIDTag("Stinky cheese resource"));
     }
 
     if ($item[mayfly bait necklace].available_amount() > 0 && get_property_int("_mayflySummons") < 30) {

--- a/Source/relay/TourGuide/Sets/Monorail.ash
+++ b/Source/relay/TourGuide/Sets/Monorail.ash
@@ -2,20 +2,16 @@ RegisterTaskGenerationFunction("SMonorailStationGenerateTasks");
 void SMonorailStationGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
 {
     if (__misc_state["can eat just about anything"] && get_property("muffinOnOrder") == "earthenware muffin tin")
-        optional_task_entries.listAppend(ChecklistEntryMake("__item earthenware muffin tin", "place.php?whichplace=monorail", ChecklistSubentryMake("Get your muffin tin back", "", "Vist the monorail's breakfast counter"), 8).ChecklistEntrySetIDTag("Monorail get muffin tin"));
-}
-
-RegisterResourceGenerationFunction("SMonorailStationBreakfastCounterGenerateResource");
-void SMonorailStationBreakfastCounterGenerateResource(ChecklistEntry [int] resource_entries)
-{
+        task_entries.listAppend(ChecklistEntryMake("__item earthenware muffin tin", "place.php?whichplace=monorail&action=monorail_downtown", ChecklistSubentryMake("Get your muffin tin back", "", "Vist the monorail's breakfast counter"), -11).ChecklistEntrySetIDTag("Monorail get muffin tin"));
+ 
     if (get_property_boolean("_muffinOrderedToday") || get_property("muffinOnOrder") == "earthenware muffin tin")
         return;
 
     item order = get_property("muffinOnOrder").lookupItem();
     if (order != $item[none]) {
-        resource_entries.listAppend(ChecklistEntryMake("__item " + order.to_string(), "place.php?whichplace=monorail", ChecklistSubentryMake("Go grab your " + order.to_string()), 5).ChecklistEntrySetIDTag("Monorail muffin resource"));
+        task_entries.listAppend(ChecklistEntryMake("__item " + order.to_string(), "place.php?whichplace=monorail&action=monorail_downtown", ChecklistSubentryMake("Go grab your " + order.to_string()), -11).ChecklistEntrySetIDTag("Monorail muffin resource"));
     }
-    else if (lookupItem("earthenware muffin tin").available_amount() > 0) {
-        resource_entries.listAppend(ChecklistEntryMake("__item earthenware muffin tin", "place.php?whichplace=monorail", ChecklistSubentryMake("Order a new muffin"), 5).ChecklistEntrySetIDTag("Monorail muffin resource"));
+    else if (lookupItem("earthenware muffin tin").available_amount() > 0 && __misc_state["in run"]) {
+        optional_task_entries.listAppend(ChecklistEntryMake("__item earthenware muffin tin", "place.php?whichplace=monorail", ChecklistSubentryMake("Order a new muffin"), 5).ChecklistEntrySetIDTag("Monorail muffin resource"));
     }
 }

--- a/Source/relay/TourGuide/Sets/Reminders.ash
+++ b/Source/relay/TourGuide/Sets/Reminders.ash
@@ -109,6 +109,22 @@ void SRemindersGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
             task_entries.listAppend(ChecklistEntryMake("__effect " + have_poison, url, ChecklistSubentryMake("Remove " + have_poison, "", methods), -11).ChecklistEntrySetIDTag("Poisoned reminder"));
         }
     }
+    if ($effect[teleportitis].have_effect() > 0)
+    {
+        string url = "inventory.php";
+		string method = "Use a soft green echo eyedrop antidote.";
+        if ($item[soft green echo eyedrop antidote].available_amount()<1)
+            method = "Acquire & use a soft green echo eyedrop antidote."
+        task_entries.listAppend(ChecklistEntryMake("__effect teleportitis", url, ChecklistSubentryMake("Remove Teleportitis", "", method), -11).ChecklistEntrySetIDTag("Teleportitis reminder"));
+    }
+	if ($effect[feeling lost].have_effect() > 0)
+    {
+        string url = "inventory.php";
+		string method = "Use a soft green echo eyedrop antidote.";
+        if ($item[soft green echo eyedrop antidote].available_amount()<1)
+            method = "Acquire & use a soft green echo eyedrop antidote."
+        task_entries.listAppend(ChecklistEntryMake("__effect Feeling Lost", url, ChecklistSubentryMake("Remove Feeling Lost", "", method), -11).ChecklistEntrySetIDTag("Feeling Lost reminder"));
+    }	
     if ($effect[Cunctatitis].have_effect() > 0 && $skill[disco nap].skill_is_usable() && $skill[adventurer of leisure].skill_is_usable())
     {
         string url = "skills.php";

--- a/Source/relay/TourGuide/Sets/Reminders.ash
+++ b/Source/relay/TourGuide/Sets/Reminders.ash
@@ -114,7 +114,7 @@ void SRemindersGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
         string url = "inventory.php";
 		string method = "Use a soft green echo eyedrop antidote.";
         if ($item[soft green echo eyedrop antidote].available_amount()<1)
-            method = "Acquire & use a soft green echo eyedrop antidote."
+            method = "Acquire & use a soft green echo eyedrop antidote.";
         task_entries.listAppend(ChecklistEntryMake("__effect teleportitis", url, ChecklistSubentryMake("Remove Teleportitis", "", method), -11).ChecklistEntrySetIDTag("Teleportitis reminder"));
     }
 	if ($effect[feeling lost].have_effect() > 0)
@@ -122,7 +122,7 @@ void SRemindersGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
         string url = "inventory.php";
 		string method = "Use a soft green echo eyedrop antidote.";
         if ($item[soft green echo eyedrop antidote].available_amount()<1)
-            method = "Acquire & use a soft green echo eyedrop antidote."
+            method = "Acquire & use a soft green echo eyedrop antidote.";
         task_entries.listAppend(ChecklistEntryMake("__effect Feeling Lost", url, ChecklistSubentryMake("Remove Feeling Lost", "", method), -11).ChecklistEntrySetIDTag("Feeling Lost reminder"));
     }	
     if ($effect[Cunctatitis].have_effect() > 0 && $skill[disco nap].skill_is_usable() && $skill[adventurer of leisure].skill_is_usable())

--- a/Source/relay/TourGuide/Sets/Skills.ash
+++ b/Source/relay/TourGuide/Sets/Skills.ash
@@ -28,6 +28,7 @@ void SSkillsGenerateResource(ChecklistEntry [int] resource_entries)
         craft_entry.importance_level = 4;
 
         int free_crafts_left = 0;
+        int free_cooks_left = 0;
         if ($effect[Inigo's Incantation of Inspiration].have_effect() >= 5) {
             free_crafts_left += $effect[Inigo's Incantation of Inspiration].have_effect() / 5;
         }

--- a/Source/relay/TourGuide/Sets/Skills.ash
+++ b/Source/relay/TourGuide/Sets/Skills.ash
@@ -43,6 +43,15 @@ void SSkillsGenerateResource(ChecklistEntry [int] resource_entries)
         if (get_property_int("homebodylCharges") > 0) {
             free_crafts_left += (get_property_int("homebodylCharges"));
         }
+        // adding cookbookbat free crafts into crafting tile        
+        if (lookupFamiliar("Cookbookbat").familiar_is_usable()) {
+            string [int] description;
+			free_cooks_left += clampi(5 - get_property_int("_cookbookbatCrafting"), 0, 5);
+			string title = "free cooking";
+			if (free_cooks_left > 0) {
+			craft_entry.subentries.listAppend(ChecklistSubentryMake(pluralise(free_cooks_left, title, title + "s") + " remaining", free_crafts_left > 0 ? "COOKING only" : "", description));
+			}
+        }
 
         int free_smiths_left = 0;
         if (__campground[$item[warbear auto-anvil]] > 0) {

--- a/Source/relay/TourGuide/Sets/Skills.ash
+++ b/Source/relay/TourGuide/Sets/Skills.ash
@@ -250,7 +250,7 @@ void SSkillsGenerateResource(ChecklistEntry [int] resource_entries)
         resource_entries.listAppend(ChecklistEntryMake("__skill Evoke Eldritch Horror", "skillz.php", ChecklistSubentryMake("Evoke Eldritch Horror", "", "Free fight."), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Evoke eldritch horror skill free fight"));
     }
     if (!get_property_boolean("_eldritchTentacleFought") && my_path().id != PATH_EXPLOSIONS) {
-        resource_entries.listAppend(ChecklistEntryMake("__skill Evoke Eldritch Horror", "place.php?whichplace=forestvillage", ChecklistSubentryMake("Science Tent Tentacle", "", "Free fight."), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Daily forest tentacle free fight"));
+        resource_entries.listAppend(ChecklistEntryMake("__skill Evoke Eldritch Horror", "place.php?whichplace=forestvillage&action=fv_scientist", ChecklistSubentryMake("Science Tent Tentacle", "", "Free fight."), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Daily forest tentacle free fight"));
     }
     
 }

--- a/Source/relay/TourGuide/Support/Banishers.ash
+++ b/Source/relay/TourGuide/Support/Banishers.ash
@@ -62,8 +62,8 @@ static
     __banish_source_length["beancannon"] = -1;
     __banish_source_length["licorice rope"] = -1;
     __banish_source_length["kgb tranquilizer dart"] = 20;
-    //__banish_source_length["breathe out"] = 20; // is it listed as hot jelly, breathe out or space jellyfish ?
-    //__banish_source_length["daily affirmation: be a mind master"] = 80; // how long does it last, exactly? is it still unknown?
+    __banish_source_length["breathe out"] = 20; // is it listed as hot jelly, breathe out or space jellyfish ?
+    __banish_source_length["daily affirmation: be a mind master"] = 80; // how long does it last, exactly? is it still unknown?
     __banish_source_length["spring-loaded front bumper"] = 30;
     __banish_source_length["mafia middle finger ring"] = 60;
     __banish_source_length["throw latte on opponent"] = 30;
@@ -73,6 +73,10 @@ static
     __banish_source_length["saber force"] = 30;
     __banish_source_length["human musk"] = -1;
     __banish_source_length["ultra smash"] = -1; // is it the right name?
+    __banish_source_length["b. l. a. r. t. spray (wide)"] = -1;
+	__banish_source_length["system sweep"] = -1;
+	__banish_source_length["feel hatred"] = 50;
+	__banish_source_length["show your boring familiar pictures"] = 100;
     
     int [string] __banish_simultaneous_limit;
     __banish_simultaneous_limit["beancannon"] = 5;


### PR DESCRIPTION
alright this is finally addressing #101 and bringing us up to matching with a ton of tiny TES changes i didn't notice in previous instances of comparing base tourguide to his repo. changes are well tracked in the billion commits in the branch, but in essence, this captures the big block of new things TES had versus the bundled/released tourguide version. here are some things missing that i would like to do before i merge this:

- add a tile for rock garden, add oliver's tavern, add the new freekill thing into freekill tile
- re-order the free fights in the free fight tile. machine elf first is super annoying.
- resource reminder for the 12 drunk pygmy fights (and glarks, probably)
- adding an x/12 progress tracker for Cubeling, w/ a note if you have a skelly key or a PYEC
- weird kramco issue where it's taking you to invsearch instead of grind.php; cannot figure this one out
- LT&T supernag is not present; there are some issues w/ the LT&T tiles, they are duplicated in our repo for some reason, we need to solve that and fix the lack of nags for it
- push version # upward, this is a lot of little but substantial changes

here are some things that were in TES' that i think i am not going to add but would like thoughts

- boombox is in resources instead of tasks, blocking its supernag at 1 fight remaining (reason to not add: we have a ton of supernags and this one is extraordinarily low priority, active management of boombox around the 11 changepoints is the kind of "stab yourself in the face to not even save a turn" thing i think just adds a lil bloat. if we add this i kind of want this to be pref-enabled, this is a weird enough use case to be not strictly desired default behavior imo)
- the orb is a resource instead of task, blocking its supernag (reason to not add: similar to above, but much more important... it's just weird to think about it as a supernag, since this very literally will be on -every turn- you have the thing equipped, which doesn't seem like a supernag, just seems like something we need to figure out a better way to handle? maybe adding a row to the bottom w/ the impending orb prediction? this one i think is needed somehow, so i am OK to potentially add it, but want to talk through alternate routes first.)
- missing olfaction+turtlesex tile (see issue #112 -- there's a ton of backend cruft around olfaction and i think we should add this tile in a similar form as TES' tile, but i do think we should incorporate/fix the Olfaction.ash logic so that it uses the ezan stuff)
- cookbookbat recipe reminder (i added the cooking reminders but the recipes are now like 500 meat in the mall, so not worth adding, especially not with colored text lol)