### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.ash]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Lots of editors read this format to help stay more consistent with tabs/spaces: https://editorconfig.org/

I set it up for spaces, but fine changing to tabs instead if that's preferred.