### PR TITLE
Add Rock Garden

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2023/Rock Garden.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Rock Garden.ash
@@ -1,0 +1,92 @@
+string gravelMessage(int gravels)
+{
+    return HTMLGenerateSpanOfClass(gravels, "r_bold") + "x groveling gravel (free kill*)";
+}
+
+string whetStoneMessage(int whetStones)
+{
+    return HTMLGenerateSpanOfClass(whetStones, "r_bold") + "x whet stone (+1 adv on food)";
+}
+
+string milestoneMessage(int milestones)
+{
+    int desertProgress = get_property_int("desertExploration");
+    return HTMLGenerateSpanOfClass(milestones, "r_bold") + "x milestone (+5% desert progress), " + (100 - desertProgress) + "% remaining";
+}
+
+// Prompt to harvest your garden in run when useful items are growing in it
+RegisterTaskGenerationFunction("IOTMRockGardenGenerateTasks");
+void IOTMRockGardenGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries) {
+    string [int] description;
+    string url = "campground.php";
+
+    int gardenGravels = __campground[$item[groveling gravel]];
+    int gardenMilestones = __campground[$item[milestone]];
+    int gardenWhetstones = __campground[$item[whet stone]];
+
+    if (!__iotms_usable[lookupItem("packet of rock seeds")] ||
+        !__misc_state["in run"] ||
+        my_path().id == PATH_COMMUNITY_SERVICE ||
+        gardenGravels + gardenMilestones + gardenWhetstones == 0)
+        return;
+
+    int desertProgress = get_property_int("desertExploration");
+
+    if (gardenGravels > 0)
+    {
+        description.listAppend(gravelMessage(gardenGravels));
+    }
+
+    if (gardenWhetstones > 0)
+    {
+        description.listAppend(whetStoneMessage(gardenWhetstones));
+    }
+
+    if (gardenMilestones > 0 && desertProgress < 100)
+    {
+        description.listAppend(milestoneMessage(gardenMilestones));
+    }
+
+    task_entries.listAppend(ChecklistEntryMake("__item rock garden guide", url, ChecklistSubentryMake("Harvest your rock garden", "", description)).ChecklistEntrySetIDTag("rock garden task"));
+}
+
+// Prompt to use garden resources when they're helpful
+RegisterResourceGenerationFunction("IOTMRockGardenGenerateResource");
+void IOTMRockGardenGenerateResource(ChecklistEntry [int] resource_entries) {
+    string [int] description;
+    string url = "campground.php";
+
+    if (!get_property_boolean("_molehillMountainUsed") && available_amount($item[molehill mountain]) > 0)
+    {
+        resource_entries.listAppend(ChecklistEntryMake("__item molehill mountain", url = "inventory.php?ftext=molehill+mountain", ChecklistSubentryMake("Molehill moleman", "", "Free scaling fight."), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Molehill free fight"));
+    }
+
+    int availableGravels = available_amount($item[groveling gravel]);
+    int availableMilestones = available_amount($item[milestone]);
+    int availableWhetStones = available_amount($item[whet stone]);
+
+    // Ascension stuff
+    if (!__misc_state["in run"] ||
+        my_path().id == PATH_COMMUNITY_SERVICE ||
+        availableGravels + availableMilestones + availableWhetstones == 0)
+        return;
+
+    int desertProgress = get_property_int("desertExploration");
+
+    if (availableGravels > 0 && $item[groveling gravel].item_is_usable())
+    {
+        description.listAppend(gravelMessage(availableGravels));
+    }
+
+    if (availableWhetStones > 0 && $item[whet stone].item_is_usable() && (__misc_state["can eat just about anything"]))
+    {
+        description.listAppend(whetStoneMessage(availableWhetStones));
+    }
+
+    if (availableMilestones > 0 && $item[milestone].item_is_usable() && desertProgress < 100)
+    {
+        description.listAppend(milestoneMessage(availableMilestones));
+    }
+
+    resource_entries.listAppend(ChecklistEntryMake("__item rock garden guide", url, ChecklistSubentryMake("Rock garden resources", "", description)).ChecklistEntrySetIDTag("rock garden resource"));
+}

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -127,3 +127,6 @@ import "relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash";
 import "relay/TourGuide/Items of the Month/2022/Jurassic Parka.ash";
 import "relay/TourGuide/Items of the Month/2022/Autumnaton.ash";
 import "relay/TourGuide/Items of the Month/2022/Cookbookbat.ash";
+
+// 2023
+import "relay/TourGuide/Items of the Month/2023/Rock Garden.ash";

--- a/Source/relay/TourGuide/Quests/Level 11 - Desert.ash
+++ b/Source/relay/TourGuide/Quests/Level 11 - Desert.ash
@@ -170,6 +170,15 @@ void QLevel11DesertGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEnt
         else
             subentry.entries.listAppend("Use your desert sightseeing pamphlets. (+15% exploration)");
     }
+    int campgroundMilestoneCount = __campground[$item[milestone]];
+    if (campgroundMilestoneCount > 0) {
+        string milestonesPlural = campgroundMilestoneCount == 1 ? "" : "s";
+        subentry.entries.listAppend(HTMLGenerateSpanFont("Harvest your rock garden milestone" + milestonesPlural + "!", "red"));
+    }
+    if ($item[milestone].available_amount() > 0 && $item[milestone].item_is_usable()) {
+        string milestonesPlural = $item[milestone].available_amount() == 1 ? "" : "s";
+        subentry.entries.listAppend("Use your milestone" + mileStonesPlural + ". (+5% exploration each)");
+    }
     if (!base_quest_state.state_boolean["Have UV-Compass eqipped"] && __quest_state["Level 11 Desert"].state_int["Desert Exploration"] < 99) {
         boolean should_output_compass_in_red = true;
         string line = "";

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -25,10 +25,14 @@ void initialiseIOTMsUsable()
         if (__campground[lookupItem("cold medicine cabinet")] > 0)
             __iotms_usable[lookupItem("cold medicine cabinet")] = true;
 
-        // Garden
-        if (__campground[lookupItem("packet of mushroom spores")] > 0)
-            __iotms_usable[lookupItem("packet of mushroom spores")] = true;
-
+        // __iotms_usable for gardens tracks whether the user has the garden installed.
+        // Gardens start returning 0 instead of 1 when the items are picked, so checking
+        // presence of the key is more useful than checking the value.
+        foreach garden in $items[packet of mushroom spores, packet of rock seeds]
+        {
+            if (__campground contains garden)
+                __iotms_usable[garden] = true;
+        }
     }
     if (florist_available() && $item[hand turkey outline].is_unrestricted()) //May 2013
         //Order of the Green Thumb Order Form is not marked as out of standard.


### PR DESCRIPTION
- Task to prompt you to harvest your rock garden resources in-run
- Resources to remind you of gravel/mile/whet stones in-run, molehill mountain even out of run
- Desert tile includes lines to harvest & use the milestone when applicable
- Molehill mountain is also included in the daily free fight tile

<img width="297" alt="Screenshot 2023-02-05 at 9 06 38 PM" src="https://user-images.githubusercontent.com/481668/216867432-cb42c38e-cfcf-43c8-90cb-74abd7c8e4bb.png">

<img width="257" alt="Screenshot 2023-02-05 at 9 14 57 PM" src="https://user-images.githubusercontent.com/481668/216867673-8970ec3b-84a1-4e8e-b074-a7ffd98a7a87.png">

(will grab a screenshot of desert tile next time I'm in-run)