### PR TITLE
Add workflow for automatically syncing testing branch

### DIFF
--- a/.github/workflows/sync-to-testing-branch.yml
+++ b/.github/workflows/sync-to-testing-branch.yml
@@ -1,0 +1,25 @@
+name: Sync Bundled-main to testing
+
+on:
+  push:
+    branches:
+      - Bundled-main
+  workflow_dispatch:
+permissions:
+  contents: write
+
+jobs:
+  sync-branch:
+    name: Sync Bundled-main to testing branch
+    runs-on: ubuntu-latest
+    steps:
+      # See https://github.com/connor-baer/action-sync-branch
+      # GitHub recommends pinning the SHA for security:
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: connor-baer/action-sync-branch@b54ed9b2c68941d1b2974a7776dc8e3d7d14073c
+        with:
+          branch: testing
+          token: ${{ secrets.GITHUB_TOKEN }}
+          force: false


### PR DESCRIPTION
Automatically syncs Bundled-main to a testing branch. This will make it so people can opt into a testing release of TourGuide and get changes as soon as they roll to main, letting us get more eyeballs on things that are recently added without sacrificing stability of the released version. I spent some time testing this on a separate personal repo and it worked great.

@docrostov When we want to get this merged, we'll need to create the testing branch for the first time and then we ought to do a push or two to confirm it works. I expect everything in the repo is already set up well for Actions but I don't have full perms to see how it's configured. Happy to work through it together at some point when we're both available.