### PR TITLE
Improve model train tile

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
@@ -23,7 +23,7 @@ boolean oreConfiguredWhenNotNeeded() {
         (to_item("asbestos ore").available_amount() >= 3 &&
          to_item("chrome ore").available_amount() >= 3 &&
          to_item("linoleum ore").available_amount() >= 3);
-    return oreConfigured && haveAllOreNeeded;
+    return __misc_state["in run"] && oreConfigured && haveAllOreNeeded;
 }
 
 boolean loggingMillConfiguredWhenNotNeeded() {
@@ -32,7 +32,7 @@ boolean loggingMillConfiguredWhenNotNeeded() {
 	int lumberNeeded = __quest_state["Level 9"].state_int["bridge lumber needed"];
     boolean haveAllPartsNeeded = __quest_state["Level 9"].mafia_internal_step > 1 ||
         (fastenersNeeded == 0 && lumberNeeded == 0);
-    return loggingMillConfigured && haveAllPartsNeeded;
+    return __misc_state["in run"] && loggingMillConfigured && haveAllPartsNeeded;
 }
 
 boolean statsConfiguredWhenNotNeeded() {
@@ -40,8 +40,8 @@ boolean statsConfiguredWhenNotNeeded() {
         (stationConfigured("brawn_silo") && my_primestat() == $stat[muscle]) ||
         (stationConfigured("brain_silo") && my_primestat() == $stat[mysticality]) ||
         (stationConfigured("groin_silo") && my_primestat() == $stat[moxie]);
-    boolean haveAllStatsNeeded = my_level() >= 13 && __misc_state["in run"];
-    return statsConfigured && haveAllStatsNeeded;
+    boolean haveAllStatsNeeded = my_level() >= 13;
+    return  __misc_state["in run"] && statsConfigured && haveAllStatsNeeded;
 }
 
 boolean shouldNag() {

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -127,7 +127,7 @@ import "relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash";
 import "relay/TourGuide/Items of the Month/2022/Jurassic Parka.ash";
 import "relay/TourGuide/Items of the Month/2022/Autumnaton.ash";
 import "relay/TourGuide/Items of the Month/2022/Cookbookbat.ash";
+import "relay/TourGuide/Items of the Month/2022/Model Train Set.ash";
 
 // 2023
 import "relay/TourGuide/Items of the Month/2023/Rock Garden.ash";
-import "relay/TourGuide/Items of the Month/2022/Model Train Set.ash";


### PR DESCRIPTION
Guard most of the misconfiguration warnings to only apply in-run. I also fixed a minor import order issue that cropped up because of model train and rock garden being added separately.