### PR TITLE
Add S.I.T. Course Certificate tile

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2023/SIT Course Certificate.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/SIT Course Certificate.ash
@@ -1,0 +1,35 @@
+boolean hasAnySkillOf(string [int] skillNames) {
+    foreach i in skillNames {
+        string skillName = skillNames[i];
+        if (lookupSkill(skillName).have_skill()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Prompt to register which SIT course you took
+RegisterTaskGenerationFunction("IOTMSITCertificateGenerateTasks");
+void IOTMSITCertificateGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries) {
+    if (!lookupItem("S.I.T. Course Completion Certificate").have())
+        return;
+
+    // Nag if we haven't picked a skill during this ascension    
+    string [int] skillNames = {"Psychogeologist", "Insectologist", "Cryptobotanist"};
+    if (hasAnySkillOf(skillNames)) {
+        return;
+    }
+
+    string [int] description;
+    string url = "inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=11116";
+    string main_title = "S.I.T. Course Enrollment";
+
+    string [int] miscPhrases = {
+        "Don't play hooky!",
+        "You already paid for it.",
+        "This one time in college...",
+    };
+    string miscPhrase = miscPhrases[random(count(miscPhrases))];
+    description.listAppend(HTMLGenerateSpanFont(miscPhrase + " Take your S.I.T. course!", "red"));
+    task_entries.listAppend(ChecklistEntryMake("__item S.I.T. Course Completion Certificate", url, ChecklistSubentryMake(main_title, description), -11).ChecklistEntrySetIDTag("S.I.T. Course Completion Certificate"));
+}

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -130,4 +130,5 @@ import "relay/TourGuide/Items of the Month/2022/Cookbookbat.ash";
 
 // 2023
 import "relay/TourGuide/Items of the Month/2023/Rock Garden.ash";
+import "relay/TourGuide/Items of the Month/2023/SIT Course Certificate.ash";
 import "relay/TourGuide/Items of the Month/2022/Model Train Set.ash";


### PR DESCRIPTION
Just started with a nag if you haven't picked any course when you first ascend.

I figure most other uses will get noticed and used from maximizer directly so it doesn't make much sense to have a regular tile for the resources, but open to ideas.

<img width="482" alt="Screenshot 2023-02-12 at 2 51 24 PM" src="https://user-images.githubusercontent.com/481668/218342536-4635195e-9122-44f8-9ed7-e9012833ce71.png">
