### PR TITLE
Add a guard for blank/not fully specified train config

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
@@ -65,6 +65,10 @@ void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, Checklist
     int whenTrainsetWasConfigured = get_property_int("lastTrainsetConfiguration");
     string[int] stations = split_string(get_property("trainsetConfiguration"), ",");
 
+    if (count(stations) < 8) {
+        description.listAppend("We can't tell how your trainset is configured. Click this tile to fix.");
+    }
+
     if (oreConfiguredWhenNotNeeded()) {
         description.listAppend(HTMLGenerateSpanFont("Have ore configured when it's not needed!", "red"));
     }


### PR DESCRIPTION
When you first swap to train set, currently mafia doesn't set the trainsetConfiguration preference.

Even if mafia fixes that in the future, we should guard this scenario anyway to ensure we don't break when people unpackage their trainset for the first time.