### PR TITLE
Add early return when we can't detect train configuration

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Model Train Set.ash
@@ -67,6 +67,8 @@ void IOTMModelTrainSetGenerateTasks(ChecklistEntry [int] task_entries, Checklist
 
     if (count(stations) < 8) {
         description.listAppend("We can't tell how your trainset is configured. Click this tile to fix.");
+        task_entries.listAppend(ChecklistEntryMake("__item toy crazy train", url, ChecklistSubentryMake(main_title, description), -11).ChecklistEntrySetIDTag("Model train set"));
+        return;
     }
 
     if (oreConfiguredWhenNotNeeded()) {


### PR DESCRIPTION
Oops, I forgot to do this with the previous change.

I have confirmed that this works. Here's how it shows up when `trainsetConfiguration` is empty string:
<img width="522" alt="Screenshot 2023-02-16 at 2 00 33 PM" src="https://user-images.githubusercontent.com/481668/219462066-c9f7ea1a-dea0-4663-ad5e-15a74846ed45.png">

Once clicking the tile to visit the workshed, it works again as normal:
<img width="521" alt="Screenshot 2023-02-16 at 2 01 49 PM" src="https://user-images.githubusercontent.com/481668/219462230-de1303af-57b9-4231-87c4-ec3b1844f394.png">

Note: an explicit TourGuide refresh is needed to make it recalc the tile – at some point I'd like to pick some people's brains about what is needed for it to refresh automatically here since much of TourGuide works that way. But that's not critical for getting this fix in.