### PR TITLE
Fix some small 8-bit bugs

### DIFF
--- a/Source/relay/TourGuide/Quests/8-bit Realm.ash
+++ b/Source/relay/TourGuide/Quests/8-bit Realm.ash
@@ -240,7 +240,9 @@ void Q8bitRealmGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
         
         if (base_quest_state.state_int["currentScore"] < 10000) 
         {
-            keyCompletionSubentry.entries.listAppend("If you max your bonus, you'll have your key in "+pluralise((10000-round(base_quest_state.state_int["currentScore"]))/400," more turn","more turns"));
+            int pointsLeft = 10000 - base_quest_state.state_int["currentScore"];
+            int minimumTurnsToGetKey = ceil(pointsLeft / 400.0); // ceil always rounds up, so any fraction of a leftover turn will add 1
+            keyCompletionSubentry.entries.listAppend("If you max your bonus, you'll have your key in "+pluralise(minimumTurnsToGetKey, "more turn", "more turns"));
         } 
         else 
         {

--- a/Source/relay/TourGuide/Quests/8-bit Realm.ash
+++ b/Source/relay/TourGuide/Quests/8-bit Realm.ash
@@ -242,7 +242,7 @@ void Q8bitRealmGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
         {
             int pointsLeft = 10000 - base_quest_state.state_int["currentScore"];
             int minimumTurnsToGetKey = ceil(pointsLeft / 400.0); // ceil always rounds up, so any fraction of a leftover turn will add 1
-            keyCompletionSubentry.entries.listAppend("If you max your bonus, you'll have your key in "+pluralise(minimumTurnsToGetKey, "more turn", "more turns"));
+            keyCompletionSubentry.entries.listAppend("If you max your bonus, you'll have your key in "+pluralise(minimumTurnsToGetKey, "more turn", "more turns")+".");
         } 
         else 
         {

--- a/Source/relay/TourGuide/Quests/8-bit Realm.ash
+++ b/Source/relay/TourGuide/Quests/8-bit Realm.ash
@@ -148,14 +148,15 @@ void Q8bitRealmGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
     }
 
     // Figure out if the user is better-suited to adventure elsewhere.
-    string highestPointColor;
+    string highestPointColor = currentColor;
 
-    foreach key, value in expectedPoints
+    foreach key, value in expectedPoints {
         if (value > expectedPoints[currentColor]) {
             if (value > expectedPoints[highestPointColor]) {
                 highestPointColor = key;
             }
         }
+    }
 
     // Now that we have calculated everything, we can finally make the tile! Before the very 
     //   detailed subentry, we have a quick statement of what the quest wants you to do. We


### PR DESCRIPTION
See the previous buggy behavior in this screenshot:
<img width="431" alt="Screenshot 2023-02-17 at 1 56 37 PM" src="https://user-images.githubusercontent.com/481668/219795791-9ac6bdf9-c72c-4625-b53c-905d5a9d9a7b.png">

2 fixes:
* Initialize highestPointColor to currentColor – This resolves the incorrect alternate route. Without this initialization, the previous code would never initialize highestPointColor if the current color already was the highest.
* Fix off-by-one issue for minimum remaining turns to get the key – The rounding was not always correct. Replaced it with `ceil` so that any fractional turns remaining always result in 1 more being added.

Both of those fixes result in this behavior when in the same state as the original screenshot:
<img width="431" alt="Screenshot 2023-02-17 at 4 22 48 PM" src="https://user-images.githubusercontent.com/481668/219796133-b8eeb28d-8671-47a2-8119-39391e3fb3dd.png">

Edit: One critical change not reflected in the screenshots above – I added a period at the end of the remaining turns to match the rest of the tile 😛
