### PR TITLE
Adjust testing branch workflow to trigger from completed bundle workflow

### DIFF
--- a/.github/workflows/sync-to-testing-branch.yml
+++ b/.github/workflows/sync-to-testing-branch.yml
@@ -1,9 +1,9 @@
 name: Sync Bundled-main to testing
 
 on:
-  push:
-    branches:
-      - Bundled-main
+  workflow_run:
+    workflows: [bundle ASH script(s), and push to new branch]
+    types: [completed]
   workflow_dispatch:
 permissions:
   contents: write
@@ -18,6 +18,8 @@ jobs:
       # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: Bundled-main
       - uses: connor-baer/action-sync-branch@b54ed9b2c68941d1b2974a7776dc8e3d7d14073c
         with:
           branch: testing


### PR DESCRIPTION
The previous workflow wasn't getting triggered properly. This one changes the trigger to act after the original workflow completes successfully.