### PR TITLE
8bit bonus turns

### DIFF
--- a/Source/relay/TourGuide/Quests/8-bit Realm.ash
+++ b/Source/relay/TourGuide/Quests/8-bit Realm.ash
@@ -113,8 +113,6 @@ void Q8bitRealmGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
     nextColor["blue"] = "green";
     nextColor["green"] = "red";
 
-    int [string] turnsInZone;
-
     int bonusTurnsRemaining = 5 - get_property("8BitBonusTurns").to_int();
     
     // Populate user's modifier for each bonus; iterates through black/red/blue/green

--- a/Source/relay/TourGuide/Quests/8-bit Realm.ash
+++ b/Source/relay/TourGuide/Quests/8-bit Realm.ash
@@ -114,15 +114,8 @@ void Q8bitRealmGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
     nextColor["green"] = "red";
 
     int [string] turnsInZone;
-    
-    // I do not like using turnsSpent; it has weird behavior w/ freeruns. Best we got tho! :-(
-    foreach key in helpfulModifier
-        turnsInZone[key] = to_location(zoneMap[key]).turns_spent;
 
-    int bonusTurnsRemaining = 5 - ((turnsInZone["black"]+
-                                turnsInZone["red"]+
-                                turnsInZone["blue"]+
-                                turnsInZone["green"]) % 5);
+    int bonusTurnsRemaining = 5 - get_property("8BitBonusTurns").to_int();
     
     // Populate user's modifier for each bonus; iterates through black/red/blue/green
     int [string] userModifier; 

--- a/Source/relay/relay_TourGuide.ash
+++ b/Source/relay/relay_TourGuide.ash
@@ -1,6 +1,6 @@
 //This script and its support scripts are in the public domain.
 
-since r26713; // $path update
+since r27273; // 8BitBonusTurns implemented
 import "relay/TourGuide/Main.ash"
 
 void main()


### PR DESCRIPTION
`.turns_spent` was unreliable and inaccurate for the 8bit realm. Switching to `8BitBonusTurns` will give us a more reliable way to keep track of how many turns we have left until the bonus shifts.