### PR TITLE
Add initial support for closed-circuit pay phone

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
@@ -10,7 +10,7 @@ void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, C
 
     int shadowLodestones = available_amount($item[Rufus's shadow lodestone]);
     if (shadowLodestones > 0) {
-        questDescription.listAppend(HTMLGenerateSpanFont("Have " + shadowLodestones + " " + pluralise($item[Rufus's shadow lodestone]) + ".", "purple"));
+        questDescription.listAppend(HTMLGenerateSpanFont("Have " + pluralise($item[Rufus's shadow lodestone]) + ".", "purple"));
     }
 
     int riftAdvsUntilNC = get_property_int("encountersUntilSRChoice");

--- a/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
@@ -1,13 +1,32 @@
+QuestState parseRufusQuestState() {
+    /*
+    Below description from Veracity's PR introducing Rufus quest tracking:
+    https://github.com/kolmafia/kolmafia/pull/1613
+    > "unstarted" -> we have not accepted a quest
+    > "started" -> we have accepted a quest but not yet fulfilled the requirement
+    > "step1" -> we have fulfilled the requirement but not called Rufus back yet to report our success
+    > (Calling Rufus back and fulfilling the quest sends us back to "unstarted".)
+
+    This works nicely with TourGuide's QuestState tracking so we can parse right out of it.
+    */
+    QuestState state = QuestState("questRufus");
+
+    // Because mafia_internal_step tracking is confusing, and the quest never actually gets
+    // marked as finished, let's add a boolean to track whether we've done the objective
+    // (but not yet called Rufus back)
+    state.state_boolean["quest objective fulfilled"] = state.mafia_internal_step == 2;
+
+    return state;
+}
+
 RegisterTaskGenerationFunction("IOTMClosedCircuitPayPhoneGenerateTasks");
-void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
-{
+void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries) {
     if (!lookupItem("closed-circuit pay phone").have())
         return;
 
-    string [int] affinityDescription;
-    string [int] questDescription;
     string url = "inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=11169";
 
+    string [int] questDescription;
     int shadowLodestones = available_amount($item[Rufus's shadow lodestone]);
     if (shadowLodestones > 0) {
         questDescription.listAppend(HTMLGenerateSpanFont("Have " + pluralise($item[Rufus's shadow lodestone]) + ".", "purple"));
@@ -16,16 +35,22 @@ void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, C
     int riftAdvsUntilNC = get_property_int("encountersUntilSRChoice");
     questDescription.listAppend(HTMLGenerateSpanFont(riftAdvsUntilNC + " encounters until NC/boss.", "black"));
 
-    if (get_property("questRufus").contains_text("step1")) {
+    QuestState state = parseRufusQuestState();
+
+    if (state.state_boolean["quest objective fulfilled"]) {
+        // We've fulfilled the quest objective but still need to call Rufus
         questDescription.listAppend(HTMLGenerateSpanFont("Call Rufus and get a lodestone", "black"));
         task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest done", "", questDescription), -11));
     }
-    else if (get_property("questRufus").contains_text("unstarted")) {
-        questDescription.listAppend(HTMLGenerateSpanFont("Have no quest accepted.", "red"));
-        optional_task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest doable now", "", questDescription), 11));
-    }
-    else if (get_property("questRufus").contains_text("started")) {
+    else if (state.started) {
         optional_task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest in progress", "", questDescription), 11));
+    }
+    else if (!state.started) {
+        boolean calledRufusToday = get_property_boolean("_shadowAffinityToday");
+        string textColor = calledRufusToday ? "black" : "red";
+        string callRufusMessage = calledRufusToday ? "Optionally call Rufus again for another (turn-taking) quest." : "Haven't called Rufus yet today.";
+        questDescription.listAppend(HTMLGenerateSpanFont(callRufusMessage, textColor));
+        optional_task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest doable now", "", questDescription), 11));
     }
 
     if (riftAdvsUntilNC == 0) {
@@ -35,15 +60,14 @@ void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, C
 
     if ($effect[Shadow Affinity].have_effect() > 0) {
         int shadowRiftFightsDoableRightNow = $effect[Shadow Affinity].have_effect();
+        string [int] affinityDescription;
         affinityDescription.listAppend(HTMLGenerateSpanFont("Shadow Rift fights are free!", "purple"));
         affinityDescription.listAppend(HTMLGenerateSpanFont("(don't use other free kills in there)", "black"));
         task_entries.listAppend(ChecklistEntryMake("__effect Shadow Affinity", url, ChecklistSubentryMake(shadowRiftFightsDoableRightNow + " Shadow Rift free fights", "", affinityDescription), -11));
     }
 }
 
-RegisterResourceGenerationFunction("IOTMClosedCircuitPayPhoneGenerateResource");
-void IOTMClosedCircuitPayPhoneGenerateResource(ChecklistEntry [int] resource_entries)
-{
+void showShadowBrickFreeKills(ChecklistEntry [int] resource_entries) {
     int shadowBricks = available_amount($item[shadow brick]);
     int shadowBrickUsesLeft = clampi(13 - get_property_int("_shadowBricksUsed"), 0, 13);
     if ($item[shadow brick].available_amount() > 0) {
@@ -56,32 +80,30 @@ void IOTMClosedCircuitPayPhoneGenerateResource(ChecklistEntry [int] resource_ent
         }
         resource_entries.listAppend(ChecklistEntryMake("__item shadow brick", "", ChecklistSubentryMake(header, "", "Win a fight without taking a turn.")).ChecklistEntrySetCombinationTag("free instakill"));
     }
+}
+
+RegisterResourceGenerationFunction("IOTMClosedCircuitPayPhoneGenerateResource");
+void IOTMClosedCircuitPayPhoneGenerateResource(ChecklistEntry [int] resource_entries) {
+    // Shadow bricks don't depend on having the IOTM
+    showShadowBrickFreeKills(resource_entries);
 
     if (!lookupItem("closed-circuit pay phone").have())
         return;
 
-    string [int] affinityDescription;
-    string [int] lodestoneDescription;
-    int shadowLodestones = available_amount($item[Rufus's shadow lodestone]);
-    
-    int rufusQuestItems;
     string url = "inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=11169";
 
-    int artifactCount = get_property("rufusDesiredArtifact").to_item().available_amount();
-    
+    int shadowLodestones = available_amount($item[Rufus's shadow lodestone]);
+
     if (shadowLodestones > 0) {
+        string [int] lodestoneDescription;
         lodestoneDescription.listAppend("30 advs of +100% init, +100% item, +200% meat, -10% combat.");
         lodestoneDescription.listAppend("Triggers on next visit to any Shadow Rift.");
         resource_entries.listAppend(ChecklistEntryMake("__item Rufus's shadow lodestone", url, ChecklistSubentryMake(shadowLodestones + " Rufus's shadow lodestones", lodestoneDescription), 5));
-    } else if (artifactCount > 0) {
-        lodestoneDescription.listAppend(HTMLGenerateSpanFont("Give Rufus that shadow quest item to get a lodestone!", "blue") + "");
-        resource_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus's shadow lodestone noncom", lodestoneDescription), 5));
     }
-    
+
     if (!get_property_boolean("_shadowAffinityToday")) {
+        string [int] affinityDescription;
         affinityDescription.listAppend("Call Rufus to get 11+ free Shadow Rift combats.");
         resource_entries.listAppend(ChecklistEntryMake("__effect Shadow Affinity", url, ChecklistSubentryMake("Shadow Affinity free fights", "", affinityDescription), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Shadow affinity free fights"));
     }
-
-
 }

--- a/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
@@ -37,7 +37,7 @@ void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, C
         int shadowRiftFightsDoableRightNow = $effect[Shadow Affinity].have_effect();
         affinityDescription.listAppend(HTMLGenerateSpanFont("Shadow Rift fights are free!", "purple"));
         affinityDescription.listAppend(HTMLGenerateSpanFont("(don't use other free kills in there)", "black"));
-        task_entries.listAppend(ChecklistEntryMake("__effect Shadow Affinity", "", ChecklistSubentryMake(shadowRiftFightsDoableRightNow + " Shadow Rift free fights", "", affinityDescription), -11));
+        task_entries.listAppend(ChecklistEntryMake("__effect Shadow Affinity", url, ChecklistSubentryMake(shadowRiftFightsDoableRightNow + " Shadow Rift free fights", "", affinityDescription), -11));
     }
 }
 

--- a/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash
@@ -1,0 +1,87 @@
+RegisterTaskGenerationFunction("IOTMClosedCircuitPayPhoneGenerateTasks");
+void IOTMClosedCircuitPayPhoneGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+    if (!lookupItem("closed-circuit pay phone").have())
+        return;
+
+    string [int] affinityDescription;
+    string [int] questDescription;
+    string url = "inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=11169";
+
+    int shadowLodestones = available_amount($item[Rufus's shadow lodestone]);
+    if (shadowLodestones > 0) {
+        questDescription.listAppend(HTMLGenerateSpanFont("Have " + shadowLodestones + " " + pluralise($item[Rufus's shadow lodestone]) + ".", "purple"));
+    }
+
+    int riftAdvsUntilNC = get_property_int("encountersUntilSRChoice");
+    questDescription.listAppend(HTMLGenerateSpanFont(riftAdvsUntilNC + " encounters until NC/boss.", "black"));
+
+    if (get_property("questRufus").contains_text("step1")) {
+        questDescription.listAppend(HTMLGenerateSpanFont("Call Rufus and get a lodestone", "black"));
+        task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest done", "", questDescription), -11));
+    }
+    else if (get_property("questRufus").contains_text("unstarted")) {
+        questDescription.listAppend(HTMLGenerateSpanFont("Have no quest accepted.", "red"));
+        optional_task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest doable now", "", questDescription), 11));
+    }
+    else if (get_property("questRufus").contains_text("started")) {
+        optional_task_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus quest in progress", "", questDescription), 11));
+    }
+
+    if (riftAdvsUntilNC == 0) {
+        questDescription.listAppend(HTMLGenerateSpanFont("Fight a boss or get an artifact", "black"));
+        task_entries.listAppend(ChecklistEntryMake("__item shadow bucket", url, ChecklistSubentryMake("Shadow Rift NC up next", "", questDescription), -11));
+    }
+
+    if ($effect[Shadow Affinity].have_effect() > 0) {
+        int shadowRiftFightsDoableRightNow = $effect[Shadow Affinity].have_effect();
+        affinityDescription.listAppend(HTMLGenerateSpanFont("Shadow Rift fights are free!", "purple"));
+        affinityDescription.listAppend(HTMLGenerateSpanFont("(don't use other free kills in there)", "black"));
+        task_entries.listAppend(ChecklistEntryMake("__effect Shadow Affinity", "", ChecklistSubentryMake(shadowRiftFightsDoableRightNow + " Shadow Rift free fights", "", affinityDescription), -11));
+    }
+}
+
+RegisterResourceGenerationFunction("IOTMClosedCircuitPayPhoneGenerateResource");
+void IOTMClosedCircuitPayPhoneGenerateResource(ChecklistEntry [int] resource_entries)
+{
+    int shadowBricks = available_amount($item[shadow brick]);
+    int shadowBrickUsesLeft = clampi(13 - get_property_int("_shadowBricksUsed"), 0, 13);
+    if ($item[shadow brick].available_amount() > 0) {
+        string header = $item[shadow brick].pluralise().capitaliseFirstLetter();
+        if (shadowBrickUsesLeft < shadowBricks) {
+            if (shadowBrickUsesLeft == 0)
+                header += " (not usable today)";
+            else
+                header += " (" + shadowBrickUsesLeft + " usable today)";
+        }
+        resource_entries.listAppend(ChecklistEntryMake("__item shadow brick", "", ChecklistSubentryMake(header, "", "Win a fight without taking a turn.")).ChecklistEntrySetCombinationTag("free instakill"));
+    }
+
+    if (!lookupItem("closed-circuit pay phone").have())
+        return;
+
+    string [int] affinityDescription;
+    string [int] lodestoneDescription;
+    int shadowLodestones = available_amount($item[Rufus's shadow lodestone]);
+    
+    int rufusQuestItems;
+    string url = "inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=11169";
+
+    int artifactCount = get_property("rufusDesiredArtifact").to_item().available_amount();
+    
+    if (shadowLodestones > 0) {
+        lodestoneDescription.listAppend("30 advs of +100% init, +100% item, +200% meat, -10% combat.");
+        lodestoneDescription.listAppend("Triggers on next visit to any Shadow Rift.");
+        resource_entries.listAppend(ChecklistEntryMake("__item Rufus's shadow lodestone", url, ChecklistSubentryMake(shadowLodestones + " Rufus's shadow lodestones", lodestoneDescription), 5));
+    } else if (artifactCount > 0) {
+        lodestoneDescription.listAppend(HTMLGenerateSpanFont("Give Rufus that shadow quest item to get a lodestone!", "blue") + "");
+        resource_entries.listAppend(ChecklistEntryMake("__item closed-circuit pay phone", url, ChecklistSubentryMake("Rufus's shadow lodestone noncom", lodestoneDescription), 5));
+    }
+    
+    if (!get_property_boolean("_shadowAffinityToday")) {
+        affinityDescription.listAppend("Call Rufus to get 11+ free Shadow Rift combats.");
+        resource_entries.listAppend(ChecklistEntryMake("__effect Shadow Affinity", url, ChecklistSubentryMake("Shadow Affinity free fights", "", affinityDescription), 5).ChecklistEntrySetCombinationTag("daily free fight").ChecklistEntrySetIDTag("Shadow affinity free fights"));
+    }
+
+
+}

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -133,3 +133,4 @@ import "relay/TourGuide/Items of the Month/2022/Model Train Set.ash";
 // 2023
 import "relay/TourGuide/Items of the Month/2023/Rock Garden.ash";
 import "relay/TourGuide/Items of the Month/2023/SIT Course Certificate.ash";
+import "relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash";


### PR DESCRIPTION
TES did most of the work on this tile and I fixed some things and rearranged a bit.

* Tracks shadow affinity, whether you have a shadow lodestone, number of encounters until the NC
* Supernags when Rufus quest is finished and can be turned in for a lodestone, or when the NC is up next
* Adds resources for shadow brick freekills, shadow affinity free fights, and the shadow waters buff

<img width="519" alt="Screenshot 2023-03-30 at 8 44 34 PM" src="https://user-images.githubusercontent.com/481668/229258885-ff4bc84f-713e-43cb-8e63-99f912dfc640.png">
<img width="353" alt="Screenshot 2023-03-29 at 8 05 14 PM" src="https://user-images.githubusercontent.com/481668/229258895-09dcbaa8-7008-4181-bd28-ec487aaf1716.png">

I have tested some in aftercore but not extensively. Nothing about the tile is different in-run but it'd be nice to get some feedback from someone who uses it realistically in-run.