### PR TITLE
Add Avatar of Shadows over Loathing tile

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2021/Underground Fireworks Shop.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Underground Fireworks Shop.ash
@@ -11,21 +11,21 @@ void IOTMUndergroundFireworksShopGenerateTasks(ChecklistEntry [int] task_entries
 			description.listAppend(HTMLGenerateSpanFont("Don't waste it on fire crackers!", "red"));
 			task_entries.listAppend(ChecklistEntryMake("__effect Ready to Eat", "", ChecklistSubentryMake("Ready to Eat!", "", description), -11));
 		}
-		if ($effect[Everything Looks Red].have_effect() == 0)
+		if ($effect[Everything Looks Red].have_effect() == 0 && my_class() != $class[pig skinner])
 		{
 			string [int] description;
 			string url = "clan_viplounge.php?action=fwshop&whichfloor=2";
 			description.listAppend(HTMLGenerateSpanFont("5x food statgain on the next thing you eat.", "red"));
 			optional_task_entries.listAppend(ChecklistEntryMake("__item red rocket", url, ChecklistSubentryMake("Fire a red rocket", "", description), 8));
 		}		
-		if ($effect[Everything Looks Blue].have_effect() == 0)
+		if ($effect[Everything Looks Blue].have_effect() == 0 && my_class() != $class[jazz agent])
 		{
 			string [int] description;
 			string url = "clan_viplounge.php?action=fwshop&whichfloor=2";
 			description.listAppend(HTMLGenerateSpanFont("More MP than your body has room for!", "blue"));
 			optional_task_entries.listAppend(ChecklistEntryMake("__item blue rocket", url, ChecklistSubentryMake("Fire a blue rocket", "", description), 8));
 		}
-		if ($effect[Everything Looks Yellow].have_effect() == 0)
+		if ($effect[Everything Looks Yellow].have_effect() == 0 && my_class() != $class[cheese wizard])
 		{
 			string [int] description;
 			string url = "clan_viplounge.php?action=fwshop&whichfloor=2";

--- a/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
@@ -1,0 +1,25 @@
+RegisterTaskGenerationFunction("PathShadowsOverLoathingGenerateTasks");
+void PathShadowsOverLoathingGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+    if (lookupSkill("Free-For-All").have_skill()) {
+        if ($effect[Everything Looks Red].have_effect() > 0) return;
+        string [int] description;
+        string main_title = HTMLGenerateSpanFont("Free-For-All castable", "red");
+        description.listAppend("Free instakill (25 adv cooldown)");
+        task_entries.listAppend(ChecklistEntryMake("__item orange boxing gloves", "", ChecklistSubentryMake(main_title, "", description), -11));
+    }
+    else if (lookupSkill("Fondeluge").have_skill()) {
+        if ($effect[Everything Looks Yellow].have_effect() > 0) return;
+        string [int] description;
+        string main_title = HTMLGenerateSpanFont("Fondeluge castable", "orange");
+        description.listAppend("Free YR (50 adv cooldown)");
+        task_entries.listAppend(ChecklistEntryMake("__skill fondeluge", "", ChecklistSubentryMake(main_title, "", description), -11));
+    }
+    else if (lookupSkill("Motif").have_skill()) {
+        if ($effect[Everything Looks Blue].have_effect() > 0) return;
+        string [int] description;
+        string main_title = HTMLGenerateSpanFont("Motif castable", "blue");
+        description.listAppend("Olfact (25 adv cooldown)");
+        task_entries.listAppend(ChecklistEntryMake("__skill Motif", "", ChecklistSubentryMake(main_title, "", description), -11));
+    }
+}

--- a/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
@@ -23,3 +23,63 @@ void PathShadowsOverLoathingGenerateTasks(ChecklistEntry [int] task_entries, Che
         task_entries.listAppend(ChecklistEntryMake("__skill Motif", "", ChecklistSubentryMake(main_title, "", description), -11));
     }
 }
+
+record CursedItem {
+    item theItem;
+    monster boss;
+    string description;
+    boolean shouldDisplay;
+};
+
+RegisterResourceGenerationFunction("PathShadowsOverLoathingGenerateResource");
+void PathShadowsOverLoathingGenerateResource(ChecklistEntry [int] resource_entries) {
+    if (my_path() != $path[Avatar of Shadows Over Loathing]) return;
+
+    CursedItem [int] cursedItems = {
+        new CursedItem(
+            $item[cursed bat paw],
+            $monster[two-headed shadow bat],
+            "+25 ML",
+            __quest_state["Boss Bat"].finished != true
+        ),
+        new CursedItem(
+            $item[cursed goblin cape],
+            $monster[goblin king's shadow],
+            "-15% combat!",
+            __quest_state["Knob Goblin King"].finished != true
+        ),
+        new CursedItem(
+            $item[cursed dragon wishbone],
+            $monster[shadowboner shadowdagon],
+            "+50% item",
+            __quest_state["Cyrpt"].finished != true
+        ),
+        new CursedItem(
+            $item[cursed blanket],
+            $monster[shadow of groar],
+            "+3 res",
+            __quest_state["Trapper"].finished != true
+        ),
+        new CursedItem(
+            $item[cursed machete],
+            $monster[corruptor shadow],
+            "+50% meat",
+            __quest_state["Level 11 Hidden City"].finished != true
+        ),
+        new CursedItem(
+            $item[cursed medallion],
+            $monster[shadow of the 1960s],
+            "+100% init",
+            __quest_state["Island War"].finished != true
+        )
+    };
+
+    string [int] description;
+    foreach index, cursedItem in cursedItems {
+        if (cursedItem.shouldDisplay) {
+            description.listAppend(`{HTMLGenerateSpanOfClass(cursedItem.boss.name, "r_bold")}: {cursedItem.description}`);
+        }
+    }
+
+    resource_entries.listAppend(ChecklistEntryMake("__monster shadow prism", "", ChecklistSubentryMake("Cursed boss drops", "", description), 2).ChecklistEntrySetIDTag("Avatar of Shadows Over Loathing cursed items resource"));
+}

--- a/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
@@ -31,10 +31,7 @@ record CursedItem {
     boolean shouldDisplay;
 };
 
-RegisterResourceGenerationFunction("PathShadowsOverLoathingGenerateResource");
-void PathShadowsOverLoathingGenerateResource(ChecklistEntry [int] resource_entries) {
-    if (my_path() != $path[Avatar of Shadows Over Loathing]) return;
-
+void showCursedItemsResourceTile(ChecklistEntry [int] resource_entries) {
     CursedItem [int] cursedItems = {
         new CursedItem(
             $item[cursed bat paw],
@@ -82,4 +79,28 @@ void PathShadowsOverLoathingGenerateResource(ChecklistEntry [int] resource_entri
     }
 
     resource_entries.listAppend(ChecklistEntryMake("__monster shadow prism", "", ChecklistSubentryMake("Cursed boss drops", "", description), 2).ChecklistEntrySetIDTag("Avatar of Shadows Over Loathing cursed items resource"));
+}
+
+void showDecurseResourceTile(ChecklistEntry [int] resource_entries) {
+    int fastenersNeeded = __quest_state["Level 9"].state_int["bridge fasteners needed"];
+    int lumberNeeded = __quest_state["Level 9"].state_int["bridge lumber needed"];
+    boolean needBridgeParts =  __quest_state["Level 9"].mafia_internal_step == 1 && // Bridge not complete yet
+        (fastenersNeeded > 0 || lumberNeeded > 0 ); // And we need some parts
+    boolean shouldDecurseBatPaw = my_level() >= 12 &&
+        __quest_state["Cyrpt"].finished == true &&
+        __quest_state["Typical Tavern"].finished == true &&
+        needBridgeParts;
+
+    if (shouldDecurseBatPaw) {
+        string description = `{HTMLGenerateSpanOfClass("cursed bat paw", "r_bold")} to get -ML for bridge parts!`;
+        resource_entries.listAppend(ChecklistEntryMake("__item uncursed bat paw", "", ChecklistSubentryMake("Useful items to decurse", "", description), 0).ChecklistEntrySetIDTag("Avatar of Shadows Over Loathing decurse resource"));
+    }
+}
+
+RegisterResourceGenerationFunction("PathShadowsOverLoathingGenerateResource");
+void PathShadowsOverLoathingGenerateResource(ChecklistEntry [int] resource_entries) {
+    if (my_path() != $path[Avatar of Shadows Over Loathing]) return;
+
+    showCursedItemsResourceTile(resource_entries);
+    showDecurseResourceTile(resource_entries);
 }

--- a/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash
@@ -78,7 +78,9 @@ void showCursedItemsResourceTile(ChecklistEntry [int] resource_entries) {
         }
     }
 
-    resource_entries.listAppend(ChecklistEntryMake("__monster shadow prism", "", ChecklistSubentryMake("Cursed boss drops", "", description), 2).ChecklistEntrySetIDTag("Avatar of Shadows Over Loathing cursed items resource"));
+    if (count(description) > 0) {
+        resource_entries.listAppend(ChecklistEntryMake("__monster shadow prism", "", ChecklistSubentryMake("Cursed boss drops", "", description), 2).ChecklistEntrySetIDTag("Avatar of Shadows Over Loathing cursed items resource"));
+    }
 }
 
 void showDecurseResourceTile(ChecklistEntry [int] resource_entries) {

--- a/Source/relay/TourGuide/Paths/Avatar of West of Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of West of Loathing.ash
@@ -143,7 +143,7 @@ void PathAvatarOfWestOfLoathingGenerateTasks(ChecklistEntry [int] task_entries, 
     class_points[$class[Snake Oiler]] += get_property_int("awolPointsSnakeoiler");
     
     item [class] tale_for_class;
-    tale_for_class[$class[Cow Puncher]] = $item[Tales of the West: Cow Punching];
+    tale_for_class[$class[Cow Puncher]] = $item[Tales of the West: \ Cow Punching];
     tale_for_class[$class[Beanslinger]] = $item[Tales of the West: Beanslinging];
     tale_for_class[$class[Snake Oiler]] = $item[Tales of the West: Snake Oiling];
     

--- a/Source/relay/TourGuide/Paths/Avatar of West of Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of West of Loathing.ash
@@ -143,7 +143,7 @@ void PathAvatarOfWestOfLoathingGenerateTasks(ChecklistEntry [int] task_entries, 
     class_points[$class[Snake Oiler]] += get_property_int("awolPointsSnakeoiler");
     
     item [class] tale_for_class;
-    tale_for_class[$class[Cow Puncher]] = $item[tales of the west: Cow Punching];
+    tale_for_class[$class[Cow Puncher]] = $item[Tales of the West: Cow Punching];
     tale_for_class[$class[Beanslinger]] = $item[Tales of the West: Beanslinging];
     tale_for_class[$class[Snake Oiler]] = $item[Tales of the West: Snake Oiling];
     

--- a/Source/relay/TourGuide/Paths/Paths import.ash
+++ b/Source/relay/TourGuide/Paths/Paths import.ash
@@ -20,3 +20,4 @@ import "relay/TourGuide/Paths/Explosions.ash";
 import "relay/TourGuide/Paths/Low Key.ash";
 import "relay/TourGuide/Paths/Grey Goo.ash";
 import "relay/TourGuide/Paths/Fall of the Dinosaurs.ash";
+import "relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash";


### PR DESCRIPTION
Started with TES's tile for the super important class skills with a few small tweaks, plus an unrelated warning fix for AoWoL.

Skill nags for the important class skills (Free-for-all, Fondeluge, Motif):
<img width="498" alt="Screenshot 2023-04-15 at 8 42 55 PM" src="https://user-images.githubusercontent.com/481668/232260201-95ffdce1-b59d-4314-acca-eb3ab4f8573c.png">

Fireworks tiles corresponding to your class skill are disabled since your class skill is much more powerful:
<img width="496" alt="Screenshot 2023-04-15 at 8 26 13 PM" src="https://user-images.githubusercontent.com/481668/232259791-01188b2b-3cee-4560-b89d-7d2986d9ffb6.png">
(in this screenshot I'm a Pig Skinner, so the red rocket doesn't show up)

Also added a resource tile with all the important boss cursed items:
<img width="333" alt="Screenshot 2023-04-15 at 6 59 45 PM" src="https://user-images.githubusercontent.com/481668/232259376-d3292f64-52b3-4cc4-b9d8-9b58e1b68258.png">

I haven't ascended into AoSoL to test the skill tiles or the quest completion part of the resource tile.