### PR TITLE
Add monkey's paw tile

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -81,35 +81,30 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
             $effect[none],
             "",
             !locationAvailable($location[The Hidden Park]) &&
-                available_amount($item[stone wool]) < 1,
+                available_amount($item[stone wool]) < 2,
             locationAvailable($location[The Hidden Temple])
         ),
         new MonkeyWish(
             $item[amulet of extreme plot significance],
             $effect[none],
             "",
-            !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+            !locationAvailable($location[The Castle In The Clouds In The Sky (Ground Floor)]) &&
+                available_amount($item[amulet of extreme plot significance]) < 1,
             locationAvailable($location[The Penultimate Fantasy Airship])
         ),
         new MonkeyWish(
             $item[mohawk wig],
             $effect[none],
             "",
-            !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
-            locationAvailable($location[The Penultimate Fantasy Airship])
-        ),
-        new MonkeyWish(
-            $item[soft green echo eyedrop antidote],
-            $effect[none],
-            "",
-            !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+            !__quest_state["Level 10"].finished &&
+                available_amount($item[mohawk wig]) < 1,
             locationAvailable($location[The Penultimate Fantasy Airship])
         ),
         new MonkeyWish(
             $item[book of matches],
             $effect[none],
             "",
-            my_ascensions() > get_property_int("hiddenTavernUnlock") &&
+            my_ascensions() != get_property_int("hiddenTavernUnlock") &&
                 $item[book of matches].available_amount() < 1,
             locationAvailable($location[The Hidden Park])
         ),
@@ -201,7 +196,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
         new MonkeyWish(
             $item[none],
             $effect[Frosty],
-            "init/item/meat for 8-bit",
+            "init/item/meat",
             !__quest_state["Level 13"].state_boolean["digital key used"] &&
                 $item[digital key].available_amount() < 1 &&
                 get_property("8BitScore") < 10000,
@@ -210,10 +205,15 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
         new MonkeyWish(
             $item[lowercase N],
             $effect[none],
-            "",
+            "summon the nagamar",
             !__quest_state["Level 13"].state_boolean["king waiting to be freed"] &&
-                $item[wand of nagamar].available_amount() < 1 &&
-                $item[lowercase N].available_amount() < 1,
+                // This accounts for being on a path that needs the wand as well
+                // as whether you already have one. See State.ash
+                __misc_state["wand of nagamar needed"] &&
+                $item[lowercase N].available_amount() < 1 &&
+                $item[ruby W].available_amount() > 0 &&
+                $item[metallic A].available_amount() > 0 &&
+                $item[heavy D].available_amount() > 0,
             locationAvailable($location[The Valley of Rof L'm Fao])
         )
     };

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -1,59 +1,55 @@
-record Wishable {
-    // If the wishable is an item, set that here. Otherwise, use $item[none].
+record MonkeyWish {
+    // If the wish is an item, set that here. Otherwise, use $item[none].
     item theItem;
 
-    // If the wishable is an effect, set that here. Otherwise, use $effect[none].
+    // If the wish is an effect, set that here. Otherwise, use $effect[none].
     effect theEffect;
 
     // If you want additional description text other than the item/effect name,
     // set that here.
     string additionalDescription;
 
-    // A boolean value indicating whether the wishable is useful at all.
+    // A boolean value indicating whether the wish is useful at all.
     boolean shouldDisplay;
 
-    // A boolean value indicating whether the wishable is currently accessible
+    // A boolean value indicating whether the wish is currently accessible
     // (since the paw will prevent wishes you can't access).
     boolean currentlyAccessible;
 };
 
-string showWishable(Wishable wishable) {
-    string color = wishable.currentlyAccessible ? "black" : "gray";
-    string wishableStr;
-    string additionalDescription = wishable.additionalDescription != "" ?
-        `: {wishable.additionalDescription}` :
+string showWish(MonkeyWish wish) {
+    string color = wish.currentlyAccessible ? "black" : "gray";
+    string wishStr;
+    string additionalDescription = wish.additionalDescription != "" ?
+        `: {wish.additionalDescription}` :
         "";
-    if (wishable.theItem != $item[none]) {
-        wishableStr = `{wishable.theItem.name}{additionalDescription}`;
-    } else if (wishable.theEffect != $effect[none]) {
-        wishableStr = `{wishable.theEffect.name}{additionalDescription}`;
+    if (wish.theItem != $item[none]) {
+        wishStr = `{wish.theItem.name}{additionalDescription}`;
+    } else if (wish.theEffect != $effect[none]) {
+        wishStr = `{wish.theEffect.name}{additionalDescription}`;
     } else {
-        wishableStr = "Unknown item/effect. Report to TourGuide devs >:(";
+        wishStr = "Unknown item/effect. Report to TourGuide devs >:(";
     }
-    return HTMLGenerateSpanFont(wishableStr, color);
+    return HTMLGenerateSpanFont(wishStr, color);
 }
 
-string [int] showWishables(Wishable [int] wishables) {
-    string [int] currentWishables = {};
-    string [int] futureWishables = {};
+string [int] showWishes(MonkeyWish [int] wishes) {
+    string [int] currentWishes = {};
+    string [int] futureWishes = {};
     // My kingdom for polymorphic filter :|
-    foreach index, wishable in wishables {
-        if (!wishable.shouldDisplay) continue;
+    foreach index, wish in wishes {
+        if (!wish.shouldDisplay) continue;
 
-        if (wishable.theItem == $item[short writ of habeas corpus]) {
-            print(__quest_state["Level 11 Hidden City"].finished);
-            print(wishable.shouldDisplay);
-        }
-        if (wishable.currentlyAccessible) {
-            currentWishables.listAppend(showWishable(wishable));
+        if (wish.currentlyAccessible) {
+            currentWishes.listAppend(showWish(wish));
         } else {
-            futureWishables.listAppend(showWishable(wishable));
+            futureWishes.listAppend(showWish(wish));
         }
     }
-    string [int] allWishables = {};
-    allWishables.listAppendList(currentWishables);
-    allWishables.listAppendList(futureWishables);
-    return allWishables;
+    string [int] allWishes = {};
+    allWishes.listAppendList(currentWishes);
+    allWishes.listAppendList(futureWishes);
+    return allWishes;
 }
 
 record MonkeySkill {
@@ -71,8 +67,8 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
     url = "main.php?action=cmonk&pwd=" + my_hash() + "";
     description.listAppend("Return to monke. Wish for items or effects:");
 
-    Wishable [int] inRunWishables = {
-        new Wishable(
+    MonkeyWish [int] inRunWishes = {
+        new MonkeyWish(
             $item[sonar-in-a-biscuit],
             $effect[none],
             "",
@@ -80,7 +76,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 !locationAvailable($location[The Boss Bat's Lair]),
             locationAvailable($location[Guano Junction])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[stone wool],
             $effect[none],
             "",
@@ -88,28 +84,28 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 available_amount($item[stone wool]) < 1,
             locationAvailable($location[The Hidden Temple])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[amulet of extreme plot significance],
             $effect[none],
             "",
             !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
             locationAvailable($location[The Penultimate Fantasy Airship])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[mohawk wig],
             $effect[none],
             "",
             !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
             locationAvailable($location[The Penultimate Fantasy Airship])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[soft green echo eyedrop antidote],
             $effect[none],
             "",
             !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
             locationAvailable($location[The Penultimate Fantasy Airship])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[book of matches],
             $effect[none],
             "",
@@ -117,14 +113,14 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 $item[book of matches].available_amount() < 1,
             locationAvailable($location[The Hidden Park])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[rusty hedge trimmers],
             $effect[none],
             "",
             get_property_int("twinPeakProgress") < 13,
             locationAvailable($location[Twin Peak])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[killing jar],
             $effect[none],
             "",
@@ -133,35 +129,35 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 available_amount($item[killing jar]) < 1,
             locationAvailable($location[The Haunted Library])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[none],
             $effect[Dirty Pear],
             HTMLGenerateSpanFont("double sleaze damage", "purple"),
             get_property_int("zeppelinProtestors") < 80,
             true
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[none],
             $effect[Painted-On Bikini],
             HTMLGenerateSpanFont("+100 sleaze damage", "purple"),
             get_property_int("zeppelinProtestors") < 80,
             true
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[glark cable],
             $effect[none],
             "",
             __quest_state["Level 11 Ron"].mafia_internal_step < 5,
             locationAvailable($location[The Red Zeppelin])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[short writ of habeas corpus],
             $effect[none],
             "",
             !__quest_state["Level 11 Hidden City"].finished,
             locationAvailable($location[The Hidden Park])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[lion oil],
             $effect[none],
             "",
@@ -169,7 +165,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 $item[lion oil].available_amount() < 1,
             locationAvailable($location[Whitey's Grove])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[bird rib],
             $effect[none],
             "",
@@ -177,7 +173,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 $item[bird rib].available_amount() < 1,
             locationAvailable($location[Whitey's Grove])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[drum machine],
             $effect[none],
             "",
@@ -185,7 +181,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 $item[drum machine].available_amount() < 1,
             locationAvailable($location[The Oasis])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[green smoke bomb],
             $effect[none],
             "",
@@ -193,7 +189,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
             !__quest_state["Level 12"].finished &&
                 locationAvailable($location[The Battlefield (Frat Uniform)])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[star chart],
             $effect[none],
             "",
@@ -202,7 +198,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 $item[star chart].available_amount() < 1,
             locationAvailable($location[The Hole In The Sky])
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[none],
             $effect[Frosty],
             "init/item/meat for 8-bit",
@@ -211,7 +207,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
                 get_property("8BitScore") < 10000,
             true
         ),
-        new Wishable(
+        new MonkeyWish(
             $item[lowercase N],
             $effect[none],
             "",
@@ -222,8 +218,8 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
         )
     };
 
-    Wishable [int] aftercoreWishables = {
-        new Wishable(
+    MonkeyWish [int] aftercoreWishes = {
+        new MonkeyWish(
             $item[bag of foreign bribes],
             $effect[none],
             "",
@@ -235,10 +231,10 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
     int monkeyWishesLeft = clampi(5 - get_property_int("_monkeyPawWishesUsed"), 0, 5);
     string [int] options;
     if (__misc_state["in run"] && my_path().id != PATH_COMMUNITY_SERVICE) {
-        options.listAppendList(showWishables(inRunWishables));
+        options.listAppendList(showWishes(inRunWishes));
     }
     if (!__misc_state["in run"]) {
-        options.listAppendList(showWishables(aftercoreWishables));
+        options.listAppendList(showWishes(aftercoreWishes));
         if (count(options) == 0) {
             options.listAppend("The poors will have to settle for wishing effects.");
         }

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -17,160 +17,6 @@ record Wishable {
     boolean currentlyAccessible;
 };
 
-Wishable [int] inRunWishables = {
-    new Wishable(
-        $item[sonar-in-a-biscuit],
-        $effect[none],
-        "",
-        get_property("questL04Bat") != "finished" &&
-            !locationAvailable($location[The Boss Bat's Lair]),
-        locationAvailable($location[Guano Junction])
-    ),
-    new Wishable(
-        $item[stone wool],
-        $effect[none],
-        "",
-        !locationAvailable($location[The Hidden Park]) &&
-            available_amount($item[stone wool]) < 1,
-        locationAvailable($location[The Hidden Temple])
-    ),
-    new Wishable(
-        $item[amulet of extreme plot significance],
-        $effect[none],
-        "",
-        !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
-        locationAvailable($location[The Penultimate Fantasy Airship])
-    ),
-    new Wishable(
-        $item[mohawk wig],
-        $effect[none],
-        "",
-        !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
-        locationAvailable($location[The Penultimate Fantasy Airship])
-    ),
-    new Wishable(
-        $item[soft green echo eyedrop antidote],
-        $effect[none],
-        "",
-        !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
-        locationAvailable($location[The Penultimate Fantasy Airship])
-    ),
-    new Wishable(
-        $item[book of matches],
-        $effect[none],
-        "",
-        my_ascensions() > get_property_int("hiddenTavernUnlock") &&
-            $item[book of matches].available_amount() < 1,
-        locationAvailable($location[The Hidden Park])
-    ),
-    new Wishable(
-        $item[rusty hedge trimmers],
-        $effect[none],
-        "",
-        get_property_int("twinPeakProgress") < 13,
-        locationAvailable($location[Twin Peak])
-    ),
-    new Wishable(
-        $item[killing jar],
-        $effect[none],
-        "",
-        !__quest_state["Level 11 Desert"].state_boolean["Killing Jar Given"] &&
-            get_property_int("desertExploration") < 100 &&
-            available_amount($item[killing jar]) < 1,
-        locationAvailable($location[The Haunted Library])
-    ),
-    new Wishable(
-        $item[none],
-        $effect[Dirty Pear],
-        HTMLGenerateSpanFont("double sleaze damage", "purple"),
-        get_property_int("zeppelinProtestors") < 80,
-        true
-    ),
-    new Wishable(
-        $item[glark cable],
-        $effect[none],
-        "",
-        __quest_state["Level 11 Ron"].mafia_internal_step < 5,
-        locationAvailable($location[The Red Zeppelin])
-    ),
-    new Wishable(
-        $item[short writ of habeas corpus],
-        $effect[none],
-        "",
-        $item[spectre scepter].available_amount() < 1,
-        locationAvailable($location[The Hidden Park])
-    ),
-    new Wishable(
-        $item[lion oil],
-        $effect[none],
-        "",
-        $item[mega gem].available_amount() < 1 &&
-            $item[lion oil].available_amount() < 1,
-        locationAvailable($location[Whitey's Grove])
-    ),
-    new Wishable(
-        $item[bird rib],
-        $effect[none],
-        "",
-        $item[mega gem].available_amount() < 1 &&
-            $item[bird rib].available_amount() < 1,
-        locationAvailable($location[Whitey's Grove])
-    ),
-    new Wishable(
-        $item[drum machine],
-        $effect[none],
-        "",
-        get_property_int("desertExploration") < 100 &&
-            $item[drum machine].available_amount() < 1,
-        locationAvailable($location[The Oasis])
-    ),
-    new Wishable(
-        $item[green smoke bomb],
-        $effect[none],
-        "",
-        __quest_state["Level 12"].state_string["Side seemingly fighting for"] != "hippy",
-        !__quest_state["Level 12"].finished &&
-            locationAvailable($location[The Battlefield (Frat Uniform)])
-    ),
-    new Wishable(
-        $item[star chart],
-        $effect[none],
-        "",
-        !__quest_state["Level 13"].state_boolean["Richard's star key used"] &&
-            $item[Richard's star key].available_amount() < 1 &&
-            $item[star chart].available_amount() < 1,
-        locationAvailable($location[The Hole In The Sky])
-    ),
-    new Wishable(
-        $item[none],
-        $effect[Frosty],
-        "item/meat for 8-bit",
-        !__quest_state["Level 13"].state_boolean["digital key used"] &&
-            $item[digital key].available_amount() < 1 &&
-            get_property("8BitScore") < 10000,
-        true
-    ),
-    new Wishable(
-        $item[lowercase N],
-        $effect[none],
-        "",
-        !__quest_state["Level 13"].state_boolean["king waiting to be freed"] &&
-            $item[wand of nagamar].available_amount() < 1 &&
-            $item[lowercase N].available_amount() < 1,
-        locationAvailable($location[The Valley of Rof L'm Fao])
-    )
-};
-
-Wishable [int] aftercoreWishables = {
-    new Wishable(
-        $item[bag of foreign bribes],
-        $effect[none],
-        "",
-        locationAvailable($location[The Ice Hotel]),
-        true
-    )
-};
-
 string showWishable(Wishable wishable) {
     string color = wishable.currentlyAccessible ? "black" : "gray";
     string wishableStr;
@@ -194,6 +40,10 @@ string [int] showWishables(Wishable [int] wishables) {
     foreach index, wishable in wishables {
         if (!wishable.shouldDisplay) continue;
 
+        if (wishable.theItem == $item[short writ of habeas corpus]) {
+            print(__quest_state["Level 11 Hidden City"].finished);
+            print(wishable.shouldDisplay);
+        }
         if (wishable.currentlyAccessible) {
             currentWishables.listAppend(showWishable(wishable));
         } else {
@@ -212,15 +62,6 @@ record MonkeySkill {
     string description;
 };
 
-MonkeySkill [int] monkeySkills = {
-    new MonkeySkill(5, $skill[Monkey Slap], "killbanish"),
-    new MonkeySkill(4, $skill[Monkey Tickle], "delevel"),
-    new MonkeySkill(3, $skill[Evil Monkey Eye], "spooky delevel"),
-    new MonkeySkill(2, $skill[Monkey Peace Sign], "heal"),
-    new MonkeySkill(1, $skill[Monkey Point], "Olfaction-lite")
-    // No need for 0 (physical damage), tile is invisible anyway
-};
-
 RegisterResourceGenerationFunction("IOTMCursedMonkeysPawGenerateResource");
 void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries) {
     if (!lookupItem("cursed monkey's paw").have()) return;
@@ -229,6 +70,160 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
     string [int] description;
     url = "main.php?action=cmonk&pwd=" + my_hash() + "";
     description.listAppend("Return to monke. Wish for items or effects:");
+
+    Wishable [int] inRunWishables = {
+        new Wishable(
+            $item[sonar-in-a-biscuit],
+            $effect[none],
+            "",
+            get_property("questL04Bat") != "finished" &&
+                !locationAvailable($location[The Boss Bat's Lair]),
+            locationAvailable($location[Guano Junction])
+        ),
+        new Wishable(
+            $item[stone wool],
+            $effect[none],
+            "",
+            !locationAvailable($location[The Hidden Park]) &&
+                available_amount($item[stone wool]) < 1,
+            locationAvailable($location[The Hidden Temple])
+        ),
+        new Wishable(
+            $item[amulet of extreme plot significance],
+            $effect[none],
+            "",
+            !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+            locationAvailable($location[The Penultimate Fantasy Airship])
+        ),
+        new Wishable(
+            $item[mohawk wig],
+            $effect[none],
+            "",
+            !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+            locationAvailable($location[The Penultimate Fantasy Airship])
+        ),
+        new Wishable(
+            $item[soft green echo eyedrop antidote],
+            $effect[none],
+            "",
+            !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+            locationAvailable($location[The Penultimate Fantasy Airship])
+        ),
+        new Wishable(
+            $item[book of matches],
+            $effect[none],
+            "",
+            my_ascensions() > get_property_int("hiddenTavernUnlock") &&
+                $item[book of matches].available_amount() < 1,
+            locationAvailable($location[The Hidden Park])
+        ),
+        new Wishable(
+            $item[rusty hedge trimmers],
+            $effect[none],
+            "",
+            get_property_int("twinPeakProgress") < 13,
+            locationAvailable($location[Twin Peak])
+        ),
+        new Wishable(
+            $item[killing jar],
+            $effect[none],
+            "",
+            !__quest_state["Level 11 Desert"].state_boolean["Killing Jar Given"] &&
+                get_property_int("desertExploration") < 100 &&
+                available_amount($item[killing jar]) < 1,
+            locationAvailable($location[The Haunted Library])
+        ),
+        new Wishable(
+            $item[none],
+            $effect[Dirty Pear],
+            HTMLGenerateSpanFont("double sleaze damage", "purple"),
+            get_property_int("zeppelinProtestors") < 80,
+            true
+        ),
+        new Wishable(
+            $item[glark cable],
+            $effect[none],
+            "",
+            __quest_state["Level 11 Ron"].mafia_internal_step < 5,
+            locationAvailable($location[The Red Zeppelin])
+        ),
+        new Wishable(
+            $item[short writ of habeas corpus],
+            $effect[none],
+            "",
+            !__quest_state["Level 11 Hidden City"].finished,
+            locationAvailable($location[The Hidden Park])
+        ),
+        new Wishable(
+            $item[lion oil],
+            $effect[none],
+            "",
+            $item[mega gem].available_amount() < 1 &&
+                $item[lion oil].available_amount() < 1,
+            locationAvailable($location[Whitey's Grove])
+        ),
+        new Wishable(
+            $item[bird rib],
+            $effect[none],
+            "",
+            $item[mega gem].available_amount() < 1 &&
+                $item[bird rib].available_amount() < 1,
+            locationAvailable($location[Whitey's Grove])
+        ),
+        new Wishable(
+            $item[drum machine],
+            $effect[none],
+            "",
+            get_property_int("desertExploration") < 100 &&
+                $item[drum machine].available_amount() < 1,
+            locationAvailable($location[The Oasis])
+        ),
+        new Wishable(
+            $item[green smoke bomb],
+            $effect[none],
+            "",
+            __quest_state["Level 12"].state_string["Side seemingly fighting for"] != "hippy",
+            !__quest_state["Level 12"].finished &&
+                locationAvailable($location[The Battlefield (Frat Uniform)])
+        ),
+        new Wishable(
+            $item[star chart],
+            $effect[none],
+            "",
+            !__quest_state["Level 13"].state_boolean["Richard's star key used"] &&
+                $item[Richard's star key].available_amount() < 1 &&
+                $item[star chart].available_amount() < 1,
+            locationAvailable($location[The Hole In The Sky])
+        ),
+        new Wishable(
+            $item[none],
+            $effect[Frosty],
+            "item/meat for 8-bit",
+            !__quest_state["Level 13"].state_boolean["digital key used"] &&
+                $item[digital key].available_amount() < 1 &&
+                get_property("8BitScore") < 10000,
+            true
+        ),
+        new Wishable(
+            $item[lowercase N],
+            $effect[none],
+            "",
+            !__quest_state["Level 13"].state_boolean["king waiting to be freed"] &&
+                $item[wand of nagamar].available_amount() < 1 &&
+                $item[lowercase N].available_amount() < 1,
+            locationAvailable($location[The Valley of Rof L'm Fao])
+        )
+    };
+
+    Wishable [int] aftercoreWishables = {
+        new Wishable(
+            $item[bag of foreign bribes],
+            $effect[none],
+            "",
+            locationAvailable($location[The Ice Hotel]),
+            true
+        )
+    };
 
     int monkeyWishesLeft = clampi(5 - get_property_int("_monkeyPawWishesUsed"), 0, 5);
     string [int] options;
@@ -245,6 +240,15 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
     if (count(options) > 0) {
         description.listAppend("Possible wishes:" + options.listJoinComponents("<hr>").HTMLGenerateIndentedText());
     }
+
+    MonkeySkill [int] monkeySkills = {
+        new MonkeySkill(5, $skill[Monkey Slap], "killbanish"),
+        new MonkeySkill(4, $skill[Monkey Tickle], "delevel"),
+        new MonkeySkill(3, $skill[Evil Monkey Eye], "spooky delevel"),
+        new MonkeySkill(2, $skill[Monkey Peace Sign], "heal"),
+        new MonkeySkill(1, $skill[Monkey Point], "Olfaction-lite")
+        // No need for 0 (physical damage), tile is invisible anyway
+    };
 
     string imageName;
     foreach index, monkeySkill in monkeySkills {

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -1,0 +1,249 @@
+record Wishable {
+    item theItem;
+    effect theEffect;
+    string additionalDescription;
+    boolean shouldDisplay;
+    boolean currentlyAccessible;
+};
+
+Wishable [int] inRunWishables = {
+    new Wishable(
+        $item[sonar-in-a-biscuit],
+        $effect[none],
+        "",
+        get_property("questL04Bat") != "finished" &&
+            !locationAvailable($location[The Boss Bat's Lair]),
+        locationAvailable($location[Guano Junction])
+    ),
+    new Wishable(
+        $item[stone wool],
+        $effect[none],
+        "",
+        !locationAvailable($location[The Hidden Park]) &&
+            available_amount($item[stone wool]) < 1,
+        locationAvailable($location[The Hidden Temple])
+    ),
+    new Wishable(
+        $item[amulet of extreme plot significance],
+        $effect[none],
+        "",
+        !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+        locationAvailable($location[The Penultimate Fantasy Airship])
+    ),
+    new Wishable(
+        $item[mohawk wig],
+        $effect[none],
+        "",
+        !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+        locationAvailable($location[The Penultimate Fantasy Airship])
+    ),
+    new Wishable(
+        $item[soft green echo eyedrop antidote],
+        $effect[none],
+        "",
+        !locationAvailable($location[The Castle In The Clouds In The Sky (Basement)]),
+        locationAvailable($location[The Penultimate Fantasy Airship])
+    ),
+    new Wishable(
+        $item[book of matches],
+        $effect[none],
+        "",
+        my_ascensions() > get_property_int("hiddenTavernUnlock") &&
+            $item[book of matches].available_amount() < 1,
+        locationAvailable($location[The Hidden Park])
+    ),
+    new Wishable(
+        $item[rusty hedge trimmers],
+        $effect[none],
+        "",
+        get_property_int("twinPeakProgress") < 13,
+        locationAvailable($location[Twin Peak])
+    ),
+    new Wishable(
+        $item[killing jar],
+        $effect[none],
+        "",
+        !__quest_state["Level 11 Desert"].state_boolean["Killing Jar Given"] &&
+            get_property_int("desertExploration") < 100 &&
+            available_amount($item[killing jar]) < 1,
+        locationAvailable($location[The Haunted Library])
+    ),
+    new Wishable(
+        $item[none],
+        $effect[Dirty Pear],
+        HTMLGenerateSpanFont("double sleaze damage", "purple"),
+        get_property_int("zeppelinProtestors") < 80,
+        true
+    ),
+    new Wishable(
+        $item[glark cable],
+        $effect[none],
+        "",
+        __quest_state["Level 11 Ron"].mafia_internal_step < 5,
+        locationAvailable($location[The Red Zeppelin])
+    ),
+    new Wishable(
+        $item[short writ of habeas corpus],
+        $effect[none],
+        "",
+        $item[spectre scepter].available_amount() < 1,
+        locationAvailable($location[The Hidden Park])
+    ),
+    new Wishable(
+        $item[lion oil],
+        $effect[none],
+        "",
+        $item[mega gem].available_amount() < 1 &&
+            $item[lion oil].available_amount() < 1,
+        locationAvailable($location[Whitey's Grove])
+    ),
+    new Wishable(
+        $item[bird rib],
+        $effect[none],
+        "",
+        $item[mega gem].available_amount() < 1 &&
+            $item[bird rib].available_amount() < 1,
+        locationAvailable($location[Whitey's Grove])
+    ),
+    new Wishable(
+        $item[drum machine],
+        $effect[none],
+        "",
+        get_property_int("desertExploration") < 100 &&
+            $item[drum machine].available_amount() < 1,
+        locationAvailable($location[The Oasis])
+    ),
+    new Wishable(
+        $item[green smoke bomb],
+        $effect[none],
+        "",
+        __quest_state["Level 12"].state_string["Side seemingly fighting for"] != "hippy",
+        !__quest_state["Level 12"].finished &&
+            locationAvailable($location[The Battlefield (Frat Uniform)])
+    ),
+    new Wishable(
+        $item[star chart],
+        $effect[none],
+        "",
+        !__quest_state["Level 13"].state_boolean["Richard's star key used"] &&
+            $item[Richard's star key].available_amount() < 1 &&
+            $item[star chart].available_amount() < 1,
+        locationAvailable($location[The Hole In The Sky])
+    ),
+    new Wishable(
+        $item[none],
+        $effect[Frosty],
+        "item/meat for 8-bit",
+        !__quest_state["Level 13"].state_boolean["digital key used"] &&
+            $item[digital key].available_amount() < 1 &&
+            get_property("8BitScore") < 10000,
+        true
+    ),
+    new Wishable(
+        $item[lowercase N],
+        $effect[none],
+        "",
+        !__quest_state["Level 13"].state_boolean["king waiting to be freed"] &&
+            $item[wand of nagamar].available_amount() < 1 &&
+            $item[lowercase N].available_amount() < 1,
+        locationAvailable($location[The Valley of Rof L'm Fao])
+    )
+};
+
+Wishable [int] aftercoreWishables = {
+    new Wishable(
+        $item[bag of foreign bribes],
+        $effect[none],
+        "",
+        locationAvailable($location[The Ice Hotel]),
+        true
+    )
+};
+
+string showWishable(Wishable wishable) {
+    string color = wishable.currentlyAccessible ? "black" : "gray";
+    string wishableStr;
+    string additionalDescription = wishable.additionalDescription != "" ?
+        `: {wishable.additionalDescription}` :
+        "";
+    if (wishable.theItem != $item[none]) {
+        wishableStr = `{wishable.theItem.name}{additionalDescription}`;
+    } else if (wishable.theEffect != $effect[none]) {
+        wishableStr = `{wishable.theEffect.name}{additionalDescription}`;
+    } else {
+        wishableStr = "Unknown item/effect. Report to TourGuide devs >:(";
+    }
+    return HTMLGenerateSpanFont(wishableStr, color);
+}
+
+string [int] showWishables(Wishable [int] wishables) {
+    string [int] currentWishables = {};
+    string [int] futureWishables = {};
+    // My kingdom for polymorphic filter :|
+    foreach index, wishable in wishables {
+        if (!wishable.shouldDisplay) continue;
+
+        if (wishable.currentlyAccessible) {
+            currentWishables.listAppend(showWishable(wishable));
+        } else {
+            futureWishables.listAppend(showWishable(wishable));
+        }
+    }
+    string [int] allWishables = {};
+    allWishables.listAppendList(currentWishables);
+    allWishables.listAppendList(futureWishables);
+    return allWishables;
+}
+
+record MonkeySkill {
+    int fingerCount;
+    skill theSkill;
+    string description;
+};
+
+MonkeySkill [int] monkeySkills = {
+    new MonkeySkill(5, $skill[Monkey Slap], "killbanish"),
+    new MonkeySkill(4, $skill[Monkey Tickle], "delevel"),
+    new MonkeySkill(3, $skill[Evil Monkey Eye], "spooky delevel"),
+    new MonkeySkill(2, $skill[Monkey Peace Sign], "heal"),
+    new MonkeySkill(1, $skill[Monkey Point], "Olfaction-lite")
+    // No need for 0 (physical damage), tile is invisible anyway
+};
+
+RegisterResourceGenerationFunction("IOTMCursedMonkeysPawGenerateResource");
+void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries) {
+    if (!lookupItem("cursed monkey's paw").have()) return;
+
+    string url;
+    string [int] description;
+    url = "main.php?action=cmonk&pwd=" + my_hash() + "";
+    description.listAppend("Return to monke. Wish for items or effects:");
+
+    int monkeyWishesLeft = clampi(5 - get_property_int("_monkeyPawWishesUsed"), 0, 5);
+    string [int] options;
+    if (__misc_state["in run"] && my_path().id != PATH_COMMUNITY_SERVICE) {
+        options.listAppendList(showWishables(inRunWishables));
+    }
+    if (!__misc_state["in run"]) {
+        options.listAppendList(showWishables(aftercoreWishables));
+        if (count(options) == 0) {
+            options.listAppend("The poors will have to settle for wishing effects.");
+        }
+    }
+
+    if (count(options) > 0) {
+        description.listAppend("Possible wishes:" + options.listJoinComponents("<hr>").HTMLGenerateIndentedText());
+    }
+
+    string imageName;
+    foreach index, monkeySkill in monkeySkills {
+        description.listAppend(HTMLGenerateSpanOfClass(pluralise(monkeySkill.fingerCount, "finger", "fingers") + ": ", "r_bold") + monkeySkill.description);
+        if (monkeySkill.fingerCount == monkeyWishesLeft) {
+            imageName = `__skill {monkeySkill.theSkill.name}`;
+        }
+    }
+
+    if (monkeyWishesLeft > 0) {
+        resource_entries.listAppend(ChecklistEntryMake(imageName, url, ChecklistSubentryMake(pluralise(monkeyWishesLeft, "monkey's paw wish", `monkey's paw wishes`), "", description)).ChecklistEntrySetIDTag("Monkey wishes"));
+    }
+}

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -1,8 +1,19 @@
 record Wishable {
+    // If the wishable is an item, set that here. Otherwise, use $item[none].
     item theItem;
+
+    // If the wishable is an effect, set that here. Otherwise, use $effect[none].
     effect theEffect;
+
+    // If you want additional description text other than the item/effect name,
+    // set that here.
     string additionalDescription;
+
+    // A boolean value indicating whether the wishable is useful at all.
     boolean shouldDisplay;
+
+    // A boolean value indicating whether the wishable is currently accessible
+    // (since the paw will prevent wishes you can't access).
     boolean currentlyAccessible;
 };
 

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -141,6 +141,13 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
             true
         ),
         new Wishable(
+            $item[none],
+            $effect[Painted-On Bikini],
+            HTMLGenerateSpanFont("+100 sleaze damage", "purple"),
+            get_property_int("zeppelinProtestors") < 80,
+            true
+        ),
+        new Wishable(
             $item[glark cable],
             $effect[none],
             "",

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -198,7 +198,7 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
         new Wishable(
             $item[none],
             $effect[Frosty],
-            "item/meat for 8-bit",
+            "init/item/meat for 8-bit",
             !__quest_state["Level 13"].state_boolean["digital key used"] &&
                 $item[digital key].available_amount() < 1 &&
                 get_property("8BitScore") < 10000,

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -77,6 +77,38 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
             locationAvailable($location[Guano Junction])
         ),
         new MonkeyWish(
+            $item[enchanted bean],
+            $effect[none],
+            "",
+            !__quest_state["Level 10"].state_boolean["beanstalk grown"] &&
+                available_amount($item[enchanted bean]) < 1,
+            locationAvailable($location[The Beanbat Chamber])
+        ),
+        new MonkeyWish(
+            $item[none],
+            $effect[Knob Goblin Perfume],
+            "",
+            !__quest_state["Level 5"].finished &&
+                available_amount($item[Knob Goblin perfume]) < 1,
+            true
+        ),
+        new MonkeyWish(
+            $item[Knob Goblin harem veil],
+            $effect[none],
+            "",
+            !__quest_state["Level 5"].finished &&
+                available_amount($item[Knob Goblin harem veil]) < 1,
+            locationAvailable($location[Cobb's Knob Harem])
+        ),
+        new MonkeyWish(
+            $item[Knob Goblin harem pants],
+            $effect[none],
+            "",
+            !__quest_state["Level 5"].finished &&
+                available_amount($item[Knob Goblin harem pants]) < 1,
+            locationAvailable($location[Cobb's Knob Harem])
+        ),
+        new MonkeyWish(
             $item[stone wool],
             $effect[none],
             "",
@@ -177,12 +209,20 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
             locationAvailable($location[The Oasis])
         ),
         new MonkeyWish(
+            $item[shadow brick],
+            $effect[none],
+            "",
+            get_property_int("_shadowBricksUsed") + available_amount($item[shadow brick]) < 13,
+            true
+        ),
+        new MonkeyWish(
             $item[green smoke bomb],
             $effect[none],
             "",
-            __quest_state["Level 12"].state_string["Side seemingly fighting for"] != "hippy",
             !__quest_state["Level 12"].finished &&
-                locationAvailable($location[The Battlefield (Frat Uniform)])
+                __quest_state["Level 12"].state_string["Side seemingly fighting for"] != "hippy",
+            __quest_state["Level 12"].state_boolean["War in progress"] &&
+                get_property_int("hippiesDefeated") >= 400
         ),
         new MonkeyWish(
             $item[star chart],

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -134,3 +134,4 @@ import "relay/TourGuide/Items of the Month/2022/Model Train Set.ash";
 import "relay/TourGuide/Items of the Month/2023/Rock Garden.ash";
 import "relay/TourGuide/Items of the Month/2023/SIT Course Certificate.ash";
 import "relay/TourGuide/Items of the Month/2023/Closed Circuit Pay Phone.ash";
+import "relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash";


### PR DESCRIPTION
Shows in-run most useful wishes, marking them gray if they're not currently accessible and removing them from the list if they're not needed anymore. Includes a reference list of all the paw skills.

<img width="364" alt="Screenshot 2023-04-23 at 12 02 08 PM" src="https://user-images.githubusercontent.com/481668/233855201-25463cd1-6d32-41bd-a9f2-549830910ff2.png">

All feedback welcome, and I'll add some comments inline in specific areas where I could use another look.