### PR TITLE
rework of tourguide pull list & minor bugfixes

### DIFF
--- a/Source/relay/TourGuide/Pulls.ash
+++ b/Source/relay/TourGuide/Pulls.ash
@@ -214,8 +214,7 @@ void generatePullList(Checklist [int] checklists)
             if ($items[sneaky pete's key,sneaky pete's key lime pie].available_amount() == 0) which_accessories.listAppend("Sneaky Pete's Breath Spray");
             if (which_accessories.count() > 0)
                 line += which_accessories.listJoinComponents(", ")+" ... get a wand and zap them!";
-            hero_key_selections.listAppend(line)
-
+            hero_key_selections.listAppend(line);
         }
         else if (__misc_state["can eat just about anything"] && availableFullness() > 0)
         {       
@@ -665,17 +664,16 @@ void generatePullList(Checklist [int] checklists)
     //   seeing and it's largely good stuff to at least remember that we 
     //   once considered a good pull.
  
-    // ... however, pre-commenting-out, I will include one meaty item at the
-    //   end of the recommendations. It doesn't save turns, really, but it's
-    //   certainly comfortable!
+    // ... however, pre-commenting-out, I will include one meat-generating 
+    //   item at the end of the recommendations. It doesn't save turns, 
+    //   really, but it's certainly comfortable!
 
-    if (my_meat() < 5000)
+    if (my_meat() < 5000) 
+    {
         item meatyItem = $item[gold wedding ring];
-        if (storage_amount($item[facsimile dictionary]) > 0) {
-            meatyItem = $item[facsimile dictionary];
-        }
+        if (storage_amount($item[facsimile dictionary]) > 0) meatyItem = $item[facsimile dictionary];
         pullable_item_list.listAppend(GPItemMake(meatyItem, "Autosells for "+autosell_price(meatyItem)+" meat.|Likely non-optimal.", 1));
-    
+    }
     
     // At best, folder holder represents a minor leveling boost and +/- combat. Better than red shoe, but not dramatically...
     // if (true)

--- a/Source/relay/TourGuide/Pulls.ash
+++ b/Source/relay/TourGuide/Pulls.ash
@@ -30,7 +30,18 @@ int pullable_amount(item it, int maximum_total_wanted)
 		amount = maximum_total_wanted - it.available_amount();
 	}
 	
-	if (amount < 0) amount = 0;
+    // Code by MadCarew to limit your pull # to just 1, not > 1.
+    if (in_ronin() && amount > 0 )
+	{
+        // Hooray for removing already-pulled stuff!
+	    string ronin_storage_pulls = get_property("_roninStoragePulls");
+	    string[int] already_pulled = split_string(ronin_storage_pulls);
+	    int requested_item = it.to_int();
+        
+        // Using the one-line if statement logic because I like it slightly better for this.
+	    amount = already_pulled contains requested_item ? 0 : 1;
+	}
+
 	return min(__misc_state_int["pulls available"], amount);
 }
 
@@ -84,6 +95,36 @@ void listAppend(GPItem [int] list, GPItem entry)
 	list[position] = entry;
 }
 
+// PULLS NOT YET ENUMERATED:
+//   - book of matches
+//   - star key stuff (star chart, greasy desk bell, star pops)
+//   - mick's inhaler
+//   - enchanted bean
+//   - tangle of rat tails
+//   - surgeon gear
+//   - sonar-in-a-biscuit
+//   - clusterbombs
+//   - disposable instant camera
+//   - bowling ball
+//   - dice gear
+//   - eleven-leaf clover
+//   - patent invisibility
+//   - PYEC, if they have a wand
+//   - batteries (car/lantern/9-volt)
+//   - glitch season reward name
+//   - guilty sprout
+//   - blueberry/bran muffin
+//   - mafia thumb ring
+//   - breathitin
+//   - carnivorous potted plant
+//   - extrovermectin
+//   - mafia middle finger ring
+//   - claw of the infernal seal (if SC)
+//   - 4-d camera
+//   - homebodyl
+//   - teacher's pen OR grey down vest
+//   - repaid diaper, in unrestricted
+
 void generatePullList(Checklist [int] checklists)
 {
     //Needs improvement.
@@ -107,6 +148,7 @@ void generatePullList(Checklist [int] checklists)
     
     if (my_path().id == PATH_COMMUNITY_SERVICE)
     	pullable_item_list.listAppend(GPItemMake($item[pocket wish], "Saves turns on everything in Community Service.", 20));
+
     if (__misc_state["need to level"])
     {
         if (my_primestat() == $stat[muscle])
@@ -221,8 +263,11 @@ void generatePullList(Checklist [int] checklists)
 	
 	if (my_primestat() == $stat[mysticality] && my_path().id != PATH_HEAVY_RAINS) //should we only suggest this for mysticality classes?
 		pullable_item_list.listAppend(GPItemMake($item[Jarlsberg's Pan], "?", 1)); //"
+
 	pullable_item_list.listAppend(GPItemMake($item[loathing legion knife], "?", 1));
+
 	pullable_item_list.listAppend(GPItemMake($item[greatest american pants], "navel runaways|others", 1));
+
 	if ($item[juju mojo mask].item_is_usable())
         pullable_item_list.listAppend(GPItemMake($item[juju mojo mask], "?", 1));
     if (__misc_state["free runs usable"])
@@ -286,13 +331,19 @@ void generatePullList(Checklist [int] checklists)
 	boolean have_super_fairy = false;
 	if ((familiar_is_usable($familiar[fancypants scarecrow]) && $item[spangly mariachi pants].available_amount() > 0) || (familiar_is_usable($familiar[mad hatrack]) && $item[spangly sombrero].available_amount() > 0))
 		have_super_fairy = true;
-	if (!have_super_fairy && my_path().id != PATH_HEAVY_RAINS && false)
-	{
-		if (familiar_is_usable($familiar[fancypants scarecrow]))
-			pullable_item_list.listAppend(GPItemMake($item[spangly mariachi pants], "2x fairy on fancypants scarecrow", 1));
-		else if (familiar_is_usable($familiar[mad hatrack]))
-			pullable_item_list.listAppend(GPItemMake($item[spangly sombrero], "2x fairy on mad hatrack", 1));
-	}
+    
+    // This never showed up because it had an added false in the condition. I am commenting it out
+    //   because I don't think anyone in unrestricted would ever want to do this?
+	
+    // if (!have_super_fairy && my_path().id != PATH_HEAVY_RAINS)
+	// {
+	// 	if (familiar_is_usable($familiar[fancypants scarecrow]))
+	// 		pullable_item_list.listAppend(GPItemMake($item[spangly mariachi pants], "2x fairy on fancypants scarecrow", 1));
+	// 	else if (familiar_is_usable($familiar[mad hatrack]))
+	// 		pullable_item_list.listAppend(GPItemMake($item[spangly sombrero], "2x fairy on mad hatrack", 1));
+	// }
+
+    // These all suck now lol
 	//pullable_item_list.listAppend(GPItemMake($item[jewel-eyed wizard hat], "a wizard is you!", 1));
 	//pullable_item_list.listAppend(GPItemMake($item[origami riding crop], "+5 stats/fight, but only if the monster dies quickly", 1)); //not useful?
 	//pullable_item_list.listAppend(GPItemMake($item[plastic pumpkin bucket], "don't know", 1)); //not useful?
@@ -306,7 +357,7 @@ void generatePullList(Checklist [int] checklists)
 	{
         string [int] food_selections;
         
-        if (__misc_state_int["fat loot tokens needed"] > 0)
+        if (__misc_state_int["fat loot tokens needed"] > 0 && my_path() != $path[A Shrunken Adventurer am I])
         {
             string [int] which_pies;
             if ($items[boris's key,boris's key lime pie].available_amount() == 0 && $item[boris's key lime pie].item_is_usable())
@@ -323,24 +374,30 @@ void generatePullList(Checklist [int] checklists)
                 line += "s";
             food_selections.listAppend(line);
         }
-        if (availableFullness() >= 5)
+        if (availableFullness() >= 5 && my_path() != $path[A Shrunken Adventurer am I])
         {
             if (my_level() >= 13 && my_path().id != PATH_G_LOVER)
                 food_selections.listAppend("hi meins");
             else if ($item[moon pie].is_unrestricted() && $item[moon pie].item_is_usable())
                 food_selections.listAppend("moon pies");
-            
             if ($item[fleetwood mac 'n' cheese].item_is_usable())
 	            food_selections.listAppend("fleetwood mac 'n' cheese" + (my_level() < 8 ? " (level 8)" : ""));
             if ($item[karma shawarma].is_unrestricted() && $item[karma shawarma].item_is_usable())
                 food_selections.listAppend("karma shawarma? (expensive" + (my_level() < 7 ? ", level 7" : "") + ")");
-            //FIXME maybe the new pasta?
         }
+        
+        // adding the legendary cookbookbat foods
+        if ($item[Deep Dish of Legend].item_is_usable() && storage_amount($item[Deep Dish of Legend]) > 0)
+	        food_selections.listAppend("Deep Dish of Legend" + (my_level() < 5 ? " (level 5)" : ""));
+        if ($item[Calzone of Legend].item_is_usable() && storage_amount($item[Calzone of Legend]) > 0)
+	        food_selections.listAppend("Calzone of Legend" + (my_level() < 5 ? " (level 5)" : ""));
+        if ($item[Pizza of Legend].item_is_usable() && storage_amount($item[Pizza of Legend]) > 0)
+	        food_selections.listAppend("Pizza of Legend" + (my_level() < 5 ? " (level 5)" : ""));
         
         string description;
         if (food_selections.count() > 0)
             description = food_selections.listJoinComponents(", ") + ", etc.";
-		pullable_item_list.listAppend(GPItemMake("Food", "hell ramen", description));
+		pullable_item_list.listAppend(GPItemMake("Food", "Deep Dish of Legend", description));
 	}
 	if (__misc_state["can drink just about anything"] && availableDrunkenness() >= 0 && inebriety_limit() >= 5)
 	{
@@ -452,21 +509,6 @@ void generatePullList(Checklist [int] checklists)
         }
     }
     
-    //alas, now obsolete
-    /*if (($item[talisman o' namsilat].available_amount() == 0 || !__quest_state["Level 9"].state_boolean["bridge complete"]) && !have_outfit_components("Swashbuckling Getup") && $item[pirate fledges].available_amount() == 0 && !__quest_state["Pirate Quest"].finished)
-    {
-        item [int] missing_outfit_components = missing_outfit_components("Swashbuckling Getup");
-        if (missing_outfit_components.count() > 0)
-        {
-            string entry = missing_outfit_components.listJoinComponents(", ", "and").capitaliseFirstLetter() + ".";
-            if ($item[eyepatch].available_amount() == 0)
-                entry += "|Or NPZR head/clockwork pirate skull to untinker for eyepatch/clockwork maid.";
-            if (!__quest_state["Pirate Quest"].state_boolean["valid"])
-            	entry += "|No, really! You can get a free bridge!";
-            pullable_item_list.listAppend(GPItemMake("Swashbuckling Getup", "__item " + missing_outfit_components[0], entry));
-        }
-    }*/
-    
     //FIXME suggest machetito?
     //FIXME suggest super marginal stuff in SCO or S&S
     //Ideas: Goat cheese, keepsake box, √spooky-gro fertilizer, harem outfit, perfume, rusty hedge trimmers, bowling ball, surgeon gear, tomb ratchets or tangles, all the other pies
@@ -515,18 +557,20 @@ void generatePullList(Checklist [int] checklists)
 	}
 	if (scrip_needed > 0 && my_path().id != PATH_COMMUNITY_SERVICE && my_path().id != PATH_EXPLOSIONS)
 	{
-		pullable_item_list.listAppend(GPItemMake($item[Shore Inc. Ship Trip Scrip], "Saves three turns each.|" + scrip_reasons.listJoinComponents(", ", "and").capitaliseFirstLetter() + ".", scrip_needed));
+		pullable_item_list.listAppend(GPItemMake($item[Shore Inc. Ship Trip Scrip], "Saves three turns each. (One per day?)|" + scrip_reasons.listJoinComponents(", ", "and").capitaliseFirstLetter() + ".", scrip_needed));
 	}
     //FIXME add hat/stuffing fluffer/blank-out
     if (availableSpleen() >= 2 && my_path().id != PATH_NUCLEAR_AUTUMN && my_path().id != PATH_G_LOVER && my_path().id != PATH_COMMUNITY_SERVICE)
     {
 		pullable_item_list.listAppend(GPItemMake($item[turkey blaster], "Burns five turns of delay in last adventured area. Costs spleen, limited uses/day.", MIN(3 - get_property_int("_turkeyBlastersUsed"), MIN(availableSpleen() / 2, 3)))); //FIXME learn what this limit is. also suggest in advance?
     }
-    if (__quest_state["Level 7"].state_boolean["alcove needs speed tricks"]) //only area that realistically could use it
+
+    if (__quest_state["Level 7"].in_progress) // this used to be an unreasonable pull but is actually pretty good now 
     {
-        pullable_item_list.listAppend(GPItemMake($item[gravy boat], "Wear to save two turns in the cyrpt.")); //marginal, especially since you're pulling a bunch of turkey blasters, but...
+        pullable_item_list.listAppend(GPItemMake($item[gravy boat], "Wear to save 3-4 turns in the cyrpt.")); 
         
     }
+
     if (!__quest_state["Level 12"].finished && __quest_state["Level 12"].state_int["frat boys left on battlefield"] >= 936 && __quest_state["Level 12"].state_int["hippies left on battlefield"] >= 936)
     {
         pullable_item_list.listAppend(GPItemMake($item[stuffing fluffer], "Saves eight turns if you use two at the start of fighting in the war.", 2));
@@ -541,6 +585,7 @@ void generatePullList(Checklist [int] checklists)
         if (!__quest_state["Level 11 Desert"].state_boolean["Black Paint Given"] && my_path().id == PATH_NUCLEAR_AUTUMN)
             pullable_item_list.listAppend(GPItemMake($item[can of black paint], "15% desert exploration.", 1));
     }
+
     if (__quest_state["Level 11 Ron"].mafia_internal_step <= 2 && __quest_state["Level 11 Ron"].state_int["protestors remaining"] > 1)
     {
         item [int] missing_freebird_components = items_missing( __misc_state["Torso aware"] ? $items[lynyrdskin cap,lynyrdskin tunic,lynyrdskin breeches,lynyrd musk] : $items[lynyrdskin cap,lynyrdskin breeches,lynyrd musk] );
@@ -563,51 +608,40 @@ void generatePullList(Checklist [int] checklists)
         
     }
     
-    if (__misc_state["need to level"] && __misc_state["Chateau Mantegna available"] && __misc_state_int["free rests remaining"] > 0 && false)
-    {
-        //This is not currently suggested because I'm not sure if it's worth it for anyone but unrestricted or the very high end speed ascension.
-        //It seems to give about as much stats as a good clover, which you can also pull, and are much cheaper.
-        //Unrestricted has up to 17 free rests. That's around 680 extra stats, which is fairly good. But leveling isn't as much of a problem either... or is it?
-        item dis_item = $item[none];
-        if (my_primestat() == $stat[muscle])
-            dis_item = $item[baobab sap];
-        else if (my_primestat() == $stat[mysticality])
-            dis_item = $item[desktop zen garden];
-        else if (my_primestat() == $stat[moxie])
-            dis_item = $item[Marvin's marvelous pill];
-        int ideal_extra_stats_worth = 20 * (__misc_state_int["free rests remaining"] + total_free_rests());
-        if (dis_item != $item[none] && dis_item.to_effect().have_effect() == 0)
-            pullable_item_list.listAppend(GPItemMake(dis_item, "+20% mainstat gain.|Use with Chateau resting; at the end of the day, rest with this potion active to gain extra stats.<br>Then rest again after rollover.<br>Worth up to " + ideal_extra_stats_worth + " " + my_primestat() + ".", 1));
-        
-    }
+    // Ezan had some cruft here for pulling XP% things for chateau rest improved stats. I removed it because it 
+    //   didn't even show and isn't relevant to unrestricted anymore, high or low end. Sorry Ezan.
+
     if ($item[Mr. Cheeng's spectacles] != $item[none])
         pullable_item_list.listAppend(GPItemMake($item[Mr. Cheeng's spectacles], "+15% item, +30% spell damage, acquire random potions in-combat.|Not particularly optimal, but fun."));
+
     if (availableSpleen() > 0 && $item[stench jelly].item_is_usable() && my_path().id != PATH_LIVE_ASCEND_REPEAT)
 	    pullable_item_list.listAppend(GPItemMake($item[stench jelly], "Skips ahead to an NC, saves 2.5? turns each.", 20));
      
     if ($item[pocket wish].item_is_usable())
 	    pullable_item_list.listAppend(GPItemMake($item[pocket wish], "Saves turns?", 20));   
     
-    //int pills_pullable = clampi(20 - (get_property_int("_powerPillUses") + $item[power pill].available_amount()), 0, 20);
     int pills_pullable = clampi(20 - get_property_int("_powerPillUses"), 0, 20);
+
     if (pills_pullable > 0 && ($familiar[ms. puck man].have_familiar() || $familiar[puck man].have_familiar()))
     {
         pullable_item_list.listAppend(GPItemMake($item[power pill], "Saves one turn each.", pills_pullable));
     }
-    if (my_meat() < 1000)
-        pullable_item_list.listAppend(GPItemMake($item[1\,970 carat gold], "Autosells for 19700 meat.|Not optimal in the slightest.", 1));
-	if ($skill[ancestral recall].have_skill() && my_adventures() < 10)
+    
+    // Commenting out the volcano gold and instead suggesting gold wedding ring or facsimilie dictionary as permastandard options
+    if (my_meat() < 5000)
+        item meatyItem = $item[gold wedding ring];
+        if (storage_amount($item[facsimile dictionary]) > 0) {
+            meatyItem = $item[facsimile dictionary];
+        }
+        pullable_item_list.listAppend(GPItemMake(meatyItem, "Autosells for "+autosell_price(meatyItem)+" meat.|Likely non-optimal.", 1));
+	
+    if ($skill[ancestral recall].have_skill() && my_adventures() < 10)
     {
         int casts = get_property_int("_ancestralRecallCasts");
         if (casts < 10)
             pullable_item_list.listAppend(GPItemMake($item[blue mana], "+3 adventures each.|Probably a bad idea.", clampi(10 - casts, 0, 10)));
     }
-    // Turning off because these are now useless.
     
-    // if (my_path().id == PATH_GELATINOUS_NOOB || my_path().id == PATH_NUCLEAR_AUTUMN)
-    // {
-    //     pullable_item_list.listAppend(GPItemMake($item[filthy lucre], "Turn into odor extractors for olfaction.", 6));
-    // }
     if (my_path().id != PATH_SLOW_AND_STEADY)
     {
     	//unify these... later...

--- a/Source/relay/TourGuide/Pulls.ash
+++ b/Source/relay/TourGuide/Pulls.ash
@@ -638,9 +638,10 @@ void generatePullList(Checklist [int] checklists)
     int hospital_progress = get_property_int("hiddenHospitalProgress");
 
     if (hospital_progress < 7) {
-        if (__misc_state["Torso aware"]) item [int] 
+        item [int] missingSurgeonComponents;
+        if (__misc_state["Torso aware"])  
             missingSurgeonComponents = items_missing($items[bloodied surgical dungarees,surgical mask,head mirror,half-size scalpel,surgical apron]);
-        if (!__misc_state["Torso aware"]) item [int] 
+        if (!__misc_state["Torso aware"])
             missingSurgeonComponents = items_missing($items[bloodied surgical dungarees,surgical mask,head mirror,half-size scalpel]);
         
         if (missingSurgeonComponents.count() > 0)
@@ -654,7 +655,7 @@ void generatePullList(Checklist [int] checklists)
     boolean hiddenTavernUnlocked = get_property_ascension("hiddenTavernUnlock");
     
     if ($item[book of matches].available_amount() == 0 && !hiddenTavernUnlocked) {
-       pullable_item_list.listAppend(GPItemMake($item[book of matches], "Unlock Cursed Punch & Bowl of Scorpions for Hidden City turnsaving", bowlingBallsNeeded));
+       pullable_item_list.listAppend(GPItemMake($item[book of matches], "Unlock Cursed Punch & Bowl of Scorpions for Hidden City turnsaving", 1));
     }
 
     // Can pull a bowling ball, I guess.
@@ -734,7 +735,7 @@ void generatePullList(Checklist [int] checklists)
 
         // If the user can use a red rocket, and user doesn't have a cleaver, suggest pulling a guilty sprout
         if (__misc_state["in run"] && __misc_state["can eat just about anything"] && available_amount($item[Clan VIP Lounge key]) > 0 && get_property("_fireworksShop").to_boolean() && my_path().id != PATH_G_LOVER) {
-            if (!__iotms_usable[$item["June Cleaver"]]) {
+            if (!__iotms_usable[$item[June Cleaver]]) {
                 int sproutStats = MAX(0, 4 * 225 * (1.0 + numeric_modifier(my_primestat().to_string() + " Experience Percent") / 100.0)); 
                 pullable_item_list.listAppend(GPItemMake($item[guilty sprout],"Food; gain "+sproutStats+" stats with a red-rocketed sprout!"));
             }

--- a/Source/relay/TourGuide/Pulls.ash
+++ b/Source/relay/TourGuide/Pulls.ash
@@ -137,7 +137,7 @@ void generatePullList(Checklist [int] checklists)
 
     // Breathitin is virtually always good. Absurdly nice pull.
     if (canUseHeavySpleeners)
-		pullable_item_list.listAppend(GPItemMake($item[Breathitin™], "5 outdoor free kills for 2 spleen", 7));
+		pullable_item_list.listAppend(GPItemMake($item[Breathitin&trade;], "5 outdoor free kills for 2 spleen", 7));
     
     // Bat-oomerang is a great freekill pull
     if (combat_items_usable && $item[replica bat-oomerang].item_is_usable())
@@ -203,7 +203,7 @@ void generatePullList(Checklist [int] checklists)
 		pullable_item_list.listAppend(GPItemMake($item[spooky putty sheet], "5 copies/day", 1));
 
     // Extro: the modern stuffer/blaster lol.
-    if (canUseHeavySpleeners) pullable_item_list.listAppend(GPItemMake($item[Extrovermectin™], "3 copies (as wanderers) for 2 spleen", 7));
+    if (canUseHeavySpleeners) pullable_item_list.listAppend(GPItemMake($item[Extrovermectin&trade;], "3 copies (as wanderers) for 2 spleen", 7));
 
     // Stuffers and blasters are still good, though blaster is strictly inferior to a breath
     if (availableSpleen() >= 2 && my_path().id != PATH_NUCLEAR_AUTUMN && my_path().id != PATH_COMMUNITY_SERVICE)
@@ -231,12 +231,12 @@ void generatePullList(Checklist [int] checklists)
     else if (lookupSkill("Expert Corner-Cutter").skill_is_usable()) {
        hasAnyFreeCrafts = true;
     }    
-    else if (get_property_int("homebodylCharges") > 0 || $item[Homebodyl™].available_amount() > 0) {
+    else if (get_property_int("homebodylCharges") > 0 || $item[Homebodyl&trade;].available_amount() > 0) {
        hasAnyFreeCrafts = true;
     }
 
     if (!hasAnyFreeCrafts)
-		pullable_item_list.listAppend(GPItemMake($item[Homebodyl], "11 free crafts for 2 spleen", 1));
+		pullable_item_list.listAppend(GPItemMake($item[Homebodyl&trade;], "11 free crafts for 2 spleen", 1));
 
     // Hero key generators save 3+ turns apiece, but if you have a zap wand, you should pull accessories instead
     if (__misc_state_int["fat loot tokens needed"] > 0) {
@@ -635,16 +635,18 @@ void generatePullList(Checklist [int] checklists)
        pullable_item_list.listAppend(GPItemMake($item[enchanted bean], "Grow it in the Nearby Plains for the Level 10 quest", 1));
     }
 
-    int hospital_progress = get_property_int("hiddenHospitalProgress");;
+    int hospital_progress = get_property_int("hiddenHospitalProgress");
 
     if (hospital_progress < 7) {
-        if (__misc_state["Torso aware"]) item [int] missingSurgeonComponents = items_missing($items[bloodied surgical dungarees,surgical mask,head mirror,half-size scalpel,surgical apron]);
-        if (!__misc_state["Torso aware"]) item [int] missingSurgeonComponents = items_missing($items[bloodied surgical dungarees,surgical mask,head mirror,half-size scalpel]);
+        if (__misc_state["Torso aware"]) item [int] 
+            missingSurgeonComponents = items_missing($items[bloodied surgical dungarees,surgical mask,head mirror,half-size scalpel,surgical apron]);
+        if (!__misc_state["Torso aware"]) item [int] 
+            missingSurgeonComponents = items_missing($items[bloodied surgical dungarees,surgical mask,head mirror,half-size scalpel]);
         
         if (missingSurgeonComponents.count() > 0)
         {
             string description = "Still need: " + missingSurgeonComponents.listJoinComponents(", ", "and").capitaliseFirstLetter() + ".";
-            pullable_item_list.listAppend(GPItemMake("Surgeon disguise for the Hidden Hospital", "__item " + missing_ninja_components[0], description));
+            pullable_item_list.listAppend(GPItemMake("Surgeon disguise for the Hidden Hospital", "__item " + missingSurgeonComponents[0], description));
         }
 
     }
@@ -696,7 +698,7 @@ void generatePullList(Checklist [int] checklists)
 
             if (__iotms_usable[$item[emotion chip]] && clampi(3 - get_property_int("_feelPrideUsed"), 0, 3) > 0) glitchDesc += "|Consider using Feel Pride to get 3x that total of stats.";
 
-            pullable_item_list.listAppend(GPItemMake(lookupItem("[glitch season reward name]", glitchDesc)));
+            pullable_item_list.listAppend(GPItemMake(lookupItem("[glitch season reward name]"), glitchDesc));
         }
 
         if (my_primestat() == $stat[muscle])
@@ -732,7 +734,7 @@ void generatePullList(Checklist [int] checklists)
 
         // If the user can use a red rocket, and user doesn't have a cleaver, suggest pulling a guilty sprout
         if (__misc_state["in run"] && __misc_state["can eat just about anything"] && available_amount($item[Clan VIP Lounge key]) > 0 && get_property("_fireworksShop").to_boolean() && my_path().id != PATH_G_LOVER) {
-            if (!__iotms_usable["June Cleaver"]) {
+            if (!__iotms_usable[$item["June Cleaver"]]) {
                 int sproutStats = MAX(0, 4 * 225 * (1.0 + numeric_modifier(my_primestat().to_string() + " Experience Percent") / 100.0)); 
                 pullable_item_list.listAppend(GPItemMake($item[guilty sprout],"Food; gain "+sproutStats+" stats with a red-rocketed sprout!"));
             }

--- a/Source/relay/TourGuide/Pulls.ash
+++ b/Source/relay/TourGuide/Pulls.ash
@@ -95,59 +95,124 @@ void listAppend(GPItem [int] list, GPItem entry)
 	list[position] = entry;
 }
 
-// PULLS NOT YET ENUMERATED:
-//   - book of matches
-//   - star key stuff (star chart, greasy desk bell, star pops)
-//   - mick's inhaler
-//   - enchanted bean
-//   - tangle of rat tails
-//   - surgeon gear
-//   - sonar-in-a-biscuit
-//   - clusterbombs
-//   - disposable instant camera
-//   - bowling ball
-//   - dice gear
-//   - eleven-leaf clover
-//   - patent invisibility
-//   - PYEC, if they have a wand
-//   - batteries (car/lantern/9-volt)
-//   - glitch season reward name
-//   - guilty sprout
-//   - blueberry/bran muffin
-//   - mafia thumb ring
-//   - breathitin
-//   - carnivorous potted plant
-//   - extrovermectin
-//   - mafia middle finger ring
-//   - claw of the infernal seal (if SC)
-//   - 4-d camera
-//   - homebodyl
-//   - teacher's pen OR grey down vest
-//   - repaid diaper, in unrestricted
 
 void generatePullList(Checklist [int] checklists)
 {
-    //Needs improvement.
+    // Start out pull list generation with some general bookkeeping
 	ChecklistEntry [int] pulls_entries;
 	
+    // Return in the event that the user has no pulls available
 	int pulls_available = __misc_state_int["pulls available"];
 	if (pulls_available <= 0)
 		return;
 	if (pulls_available > 0)
 		pulls_entries.listAppend(ChecklistEntryMake("special subheader", "", ChecklistSubentryMake(pluralise(pulls_available, "pull", "pulls") + " remaining")).ChecklistEntrySetIDTag("Pulls special subheader"));
 	
+    // Establish your base lists & variables
 	item [int] pullable_list_item;
 	int [int] pullable_list_max_wanted;
 	string [int] pullable_list_reason;
-	
 	GPItem [int] pullable_item_list;
-    
     boolean combat_items_usable = true;
+
+    // Set a single path-related variable
     if (my_path().id == PATH_POCKET_FAMILIARS)
     	combat_items_usable = false;
+
+
+    // =====================================================================
+    // ------ SECTION #1: 3+ TURNS -----------------------------------------
+    // =====================================================================
     
-    if (my_path().id == PATH_COMMUNITY_SERVICE)
-    	pullable_item_list.listAppend(GPItemMake($item[pocket wish], "Saves turns on everything in Community Service.", 20));
+    // Pulls in this category are highly valuable turnsave pulls that can 
+    //   either bypass certain quests entirely or save entire chunks of 
+    //   quests. Everything here is stupid valuable.
+
+    //   - 3+ turns: star key stuff (star chart, greasy desk bell, star pops)
+    //   - 3+ turns: PYEC, if they have a wand
+    //   - 3+ turns: batteries (car/lantern/9-volt); assuming in standard you use the buff well + get 1-2 bombs out of each
+    //   - 3+ turns: breathitin
+    //   - 3+ turns: carnivorous potted plant
+    //   - 3+ turns: extrovermectin
+    //   - 3+ turns: homebodyl (if no cookbookbat)
+    //   - 3+ turns: repaid diaper, in unrestricted
+
+    // Rain-Doh & Spooky Putty; 5 copies is roughly 3+ turns in value, even without going in delay.
+	if ($item[empty rain-doh can].available_amount() == 0 && $item[can of rain-doh].available_amount() == 0 && $item[can of rain-doh].item_is_usable())
+		pullable_item_list.listAppend(GPItemMake($item[can of rain-doh], "5 copies/day|everything really", 1));
+	if ($items[empty rain-doh can,can of rain-doh,spooky putty monster].available_amount() == 0 && $item[spooky putty sheet].item_is_usable())
+		pullable_item_list.listAppend(GPItemMake($item[spooky putty sheet], "5 copies/day", 1));
+
+    // This is a catch-all for familiar weight pulls, which are only useful if the user can use boots/bander
+    if (!__misc_state["familiars temporarily blocked"] && $familiar[pair of stomping boots].is_unrestricted() && __misc_state["free runs usable"] && __misc_state["free runs available"]) {
+
+        // Sort of a pain, but if they have it, it's a nice +4 runs...
+        if ($item[snow suit].item_is_usable()) pullable_item_list.listAppend(GPItemMake($item[snow suit], "+20 familiar weight for a while, +4 free runs", 1));
+    }
+
+
+    // =====================================================================
+    // ------ SECTION #2: 1-2 TURNS ----------------------------------------
+    // =====================================================================
+    
+    // Not as valuable as the section #1 pulls, but better than average. In
+    //   general, these pulls should be considered above quest misses and 
+    //   are less related to explicit in-run findings.
+    
+    //   - 1-2 turn: eleven-leaf clover
+    //   - 1-2 turn: mick's inhaler
+    //   - 1-2 turn: milestone
+    //   - 1-2 turn: patent invisibility
+    //   - 1-2 turn: mafia middle finger ring
+    //   - 1-2 turn: claw of the infernal seal (if SC)
+    //   - 1-2 turn: 4-d camera
+    //   - 1-2 turn: teacher's pen OR grey down vest
+    //   - 1-2 turn: shadow brick
+    //   - 1-2 turn: groveling gravel
+
+    if ($item[v for vivala mask].item_is_usable()) pullable_item_list.listAppend(GPItemMake($item[v for vivala mask], "1 free banish per day", 1));
+
+    // =====================================================================
+    // ------ SECTION #3: QUEST MISSES -------------------------------------
+    // =====================================================================
+    
+    // Most pulls in here can be (relatively) painlessly routed into your 
+    //   run. However, if you don't have them, they're good pulls, just not
+    //   universally valuable like the 1/2 tier pulls. A few of these end
+    //   up being better than pulls above if you miss them, too.
+
+    //   - QUEST MISS: book of matches
+    //   - QUEST MISS: enchanted bean
+    //   - QUEST MISS: tangle of rat tails
+    //   - QUEST MISS: surgeon gear
+    //   - QUEST MISS: sonar-in-a-biscuit
+    //   - QUEST MISS: clusterbombs
+    //   - QUEST MISS: disposable instant camera
+    //   - QUEST MISS: bowling ball
+    
+    if (__quest_state["Level 10"].mafia_internal_step >= 8)
+    {
+    	if (__quest_state["Level 10"].mafia_internal_step == 8 && $item[amulet of extreme plot significance].available_amount() == 0)
+        {
+        	pullable_item_list.listAppend(GPItemMake($item[amulet of extreme plot significance], "Speeds up castle basement.", 1));
+        }
+        if (!__quest_state["Level 10"].finished && $item[mohawk wig].available_amount() == 0 && (!lookupSkill("Comprehensive Cartography").skill_is_usable() || $item[model airship].available_amount() == 0))
+        {
+            pullable_item_list.listAppend(GPItemMake($item[mohawk wig], "Speeds up top floor of castle.", 1));
+        }
+    }
+
+    // =====================================================================
+    // ------ SECTION #4: LEVELING -----------------------------------------
+    // =====================================================================
+    
+    // Pulls in this category aren't really measured by turn-value; they're
+    //   measured by how many stats they give the user. Ergo, in cases where
+    //   it's possible, try to include the # of expected stats in the desc
+
+    //   - LEVELING: glitch season reward name
+    //   - LEVELING guilty sprout
+    //   - LEVELING/TURNBLOAT: blueberry/bran muffin
 
     if (__misc_state["need to level"])
     {
@@ -181,88 +246,142 @@ void generatePullList(Checklist [int] checklists)
             if (my_path().id == PATH_THE_SOURCE)
                 pullable_item_list.listAppend(GPItemMake($item[wal-mart overalls], "+4 mainstat/fight"));
         }
+
+        int vampingStats = MIN(500, 4 * my_basestat(my_primestat())) * (1.0 + numeric_modifier(my_primestat().to_string() + " Experience Percent") / 100.0);
+        pullable_item_list.listAppend(GPItemMake($item[plastic vampire fangs], "Gain"+vampingStats+" mainstat, once/day; costs a turn!", 1));
     }
-	
-	//IOTMs:
-	if ($item[empty rain-doh can].available_amount() == 0 && $item[can of rain-doh].available_amount() == 0 && $item[can of rain-doh].item_is_usable())
-		pullable_item_list.listAppend(GPItemMake($item[can of rain-doh], "5 copies/day|everything really", 1));
-	if ($items[empty rain-doh can,can of rain-doh,spooky putty monster].available_amount() == 0 && $item[spooky putty sheet].item_is_usable())
-		pullable_item_list.listAppend(GPItemMake($item[spooky putty sheet], "5 copies/day", 1));
-    if (true)
-    {
-        string line = "So many things!";
-        if ($item[over-the-shoulder folder holder].storage_amount() > 0 && $item[over-the-shoulder folder holder].item_is_usable())
-        {
-            string [int] description;
-            string [item] folder_descriptions;
-            
-            folder_descriptions[$item[folder (red)]] = "+20 muscle";
-            folder_descriptions[$item[folder (blue)]] = "+20 myst";
-            folder_descriptions[$item[folder (green)]] = "+20 moxie";
-            folder_descriptions[$item[folder (magenta)]] = "+15 muscle +15 myst";
-            folder_descriptions[$item[folder (cyan)]] = "+15 myst +15 moxie";
-            folder_descriptions[$item[folder (yellow)]] = "+15 muscle +15 moxie";
-            folder_descriptions[$item[folder (smiley face)]] = "+2 muscle stat/fight";
-            folder_descriptions[$item[folder (wizard)]] = "+2 myst stat/fight";
-            folder_descriptions[$item[folder (space skeleton)]] = "+2 moxie stat/fight";
-            folder_descriptions[$item[folder (D-Team)]] = "+1 stat/fight";
-            folder_descriptions[$item[folder (Ex-Files)]] = "+5% combat";
-            folder_descriptions[$item[folder (skull and crossbones)]] = "-5% combat";
-            folder_descriptions[$item[folder (Knight Writer)]] = "+40% init";
-            folder_descriptions[$item[folder (Jackass Plumber)]] = "+25 ML";
-            folder_descriptions[$item[folder (holographic fractal)]] = "+4 all res";
-            folder_descriptions[$item[folder (barbarian)]] = "stinging damage";
-            folder_descriptions[$item[folder (rainbow unicorn)]] = "prismatic stinging damage";
-            folder_descriptions[$item[folder (Seawolf)]] = "-pressure penalty";
-            folder_descriptions[$item[folder (dancing dolphins)]] = "+50% item (underwater)";
-            folder_descriptions[$item[folder (catfish)]] = "+15 familiar weight (underwater)";
-            folder_descriptions[$item[folder (tranquil landscape)]] = "15 DR / 15 HP & MP regen";
-            folder_descriptions[$item[folder (owl)]] = "+500% item (dreadsylvania)";
-            folder_descriptions[$item[folder (Stinky Trash Kid)]] = "passive stench damage";
-            folder_descriptions[$item[folder (sports car)]] = "+5 adv";
-            folder_descriptions[$item[folder (sportsballs)]] = "+5 PVP fights";
-            folder_descriptions[$item[folder (heavy metal)]] = "+5 familiar weight";
-            folder_descriptions[$item[folder (Yedi)]] = "+50% spell damage";
-            folder_descriptions[$item[folder (KOLHS)]] = "+50% item (KOLHS)";
-            
-            foreach s in $slots[folder1,folder2,folder3]
-            {
-                item folder = s.equipped_item();
-                if (folder == $item[none]) continue;
-                
-                if (folder_descriptions contains folder)
-                    description.listAppend(folder_descriptions[folder]);
-            }
-            if (description.count() > 0)
-                line = description.listJoinComponents(" / ");
-        }
-        pullable_item_list.listAppend(GPItemMake($item[over-the-shoulder folder holder], line, 1));
-    }
+
     
-	pullable_item_list.listAppend(GPItemMake($item[pantsgiving], "5x banish/day|+2 stats/fight|+15% items|2 extra fullness (realistically)", 1));
-    if (!__misc_state["familiars temporarily blocked"] && $item[snow suit].item_is_usable()) //relevant in heavy rains, on the +item/+meat underwater familiars
-        pullable_item_list.listAppend(GPItemMake($item[snow suit], "+20 familiar weight for a while" + (($familiar[pair of stomping boots].is_unrestricted() && __misc_state["free runs usable"]) ? ", +4 free runs" : "") + "|+10% item|spleen items", 1));
-    if (!__misc_state["familiars temporarily blocked"] && ($item[protonic accelerator pack].available_amount() == 0 || $familiar[machine elf].familiar_is_usable())) //if you have a machine elf, it might be worth pulling a bjorn with a protonic pack anyways
-    {
-        if ($item[Buddy Bjorn].storage_amount() > 0)
-            pullable_item_list.listAppend(GPItemMake($item[Buddy Bjorn], "+10ML/+lots MP hat|or +item/+init/+meat/etc", 1));
-        else if ($item[buddy bjorn].available_amount() == 0)
-            pullable_item_list.listAppend(GPItemMake($item[crown of thrones], "+10ML/+lots MP hat|or +item/+init/+meat/etc", 1));
+    // =====================================================================
+    // ------ SECTION #5: PATH-SPECIFIC ------------------------------------
+    // =====================================================================
+    
+    // Pulls in this category are path-specific pulls that are useful in a 
+    //   particular challenge path context and not particularly useful in
+    //   other situations. 
+
+    if (my_path().id == PATH_COMMUNITY_SERVICE)
+    	pullable_item_list.listAppend(GPItemMake($item[pocket wish], "Saves turns on everything in Community Service.", 20));
+
+    if (my_path().id == PATH_AVATAR_OF_BORIS) {
+        if ($item[boris's helm].item_is_usable()) pullable_item_list.listAppend(GPItemMake($item[boris's helm], "+15ML/+5 familiar weight/+init/+mp regeneration/+weapon damage", 1));
     }
-    if ($item[boris's helm].item_is_usable())
-	    pullable_item_list.listAppend(GPItemMake($item[boris's helm], "+15ML/+5 familiar weight/+init/+mp regeneration/+weapon damage", 1));
-    if (__misc_state["need to level"])
-    {
-        pullable_item_list.listAppend(GPItemMake($item[plastic vampire fangs], "Large stat gain, once/day.", 1));
-	if ($item[operation patriot shield].item_is_usable())
-            pullable_item_list.listAppend(GPItemMake($item[operation patriot shield], "+america", 1));
-        pullable_item_list.listAppend(GPItemMake($item[the crown of ed the undying], "Various in-run modifiers. (init, HP, ML/item/meat/etc)", 1));
+
+    if (my_path().id == PATH_AVATAR_OF_JARLSBERG) {
+        pullable_item_list.listAppend(GPItemMake($item[Jarlsberg's Pan], "Cook up some cool Jarlsberg potions!", 1));
     }
-    if ($item[v for vivala mask].item_is_usable())
-        pullable_item_list.listAppend(GPItemMake($item[v for vivala mask], "?", 1));
 	
-	if (my_primestat() == $stat[mysticality] && my_path().id != PATH_HEAVY_RAINS) //should we only suggest this for mysticality classes?
-		pullable_item_list.listAppend(GPItemMake($item[Jarlsberg's Pan], "?", 1)); //"
+    // =====================================================================
+    // ------ SECTION #6: TURNBLOAT ----------------------------------------
+    // =====================================================================
+    
+    // Pulls in this category are only really worth it if they help you make
+    //   daycount. You probably ignore it in most unrestricted contexts, but 
+    //   instead of flat ignoring it I think you just throw these at the
+    //   absolute bottom of the list.
+    
+    // PANTSGIVING: banishes aren't really turnsaving anymore, you'd only pull it for unrestricted bloat.
+    pullable_item_list.listAppend(GPItemMake($item[pantsgiving], "5x non-free banishes|+2 stats/fight|+15% items|2 extra fullness (realistically)", 1));
+    
+    
+    // =====================================================================
+    // ------ SECTION #7: MARGINAL GRAVEYARD -------------------------------
+    // =====================================================================
+    
+    // Pulls in this category are pretty bad. Most of them are leftover from 
+    //   old metas where the were mildly useful. Commenting them out... for
+    //   now, mostly because there's possibly some future use case I'm not 
+    //   seeing and it's largely good stuff to at least remember that we 
+    //   once considered a good pull.
+    
+    // At best, folder holder represents a minor leveling boost and +/- combat. Better than red shoe, but not dramatically...
+    // if (true)
+    // {
+    //     string line = "So many things!";
+    //     if ($item[over-the-shoulder folder holder].storage_amount() > 0 && $item[over-the-shoulder folder holder].item_is_usable())
+    //     {
+    //         string [int] description;
+    //         string [item] folder_descriptions;
+            
+    //         folder_descriptions[$item[folder (red)]] = "+20 muscle";
+    //         folder_descriptions[$item[folder (blue)]] = "+20 myst";
+    //         folder_descriptions[$item[folder (green)]] = "+20 moxie";
+    //         folder_descriptions[$item[folder (magenta)]] = "+15 muscle +15 myst";
+    //         folder_descriptions[$item[folder (cyan)]] = "+15 myst +15 moxie";
+    //         folder_descriptions[$item[folder (yellow)]] = "+15 muscle +15 moxie";
+    //         folder_descriptions[$item[folder (smiley face)]] = "+2 muscle stat/fight";
+    //         folder_descriptions[$item[folder (wizard)]] = "+2 myst stat/fight";
+    //         folder_descriptions[$item[folder (space skeleton)]] = "+2 moxie stat/fight";
+    //         folder_descriptions[$item[folder (D-Team)]] = "+1 stat/fight";
+    //         folder_descriptions[$item[folder (Ex-Files)]] = "+5% combat";
+    //         folder_descriptions[$item[folder (skull and crossbones)]] = "-5% combat";
+    //         folder_descriptions[$item[folder (Knight Writer)]] = "+40% init";
+    //         folder_descriptions[$item[folder (Jackass Plumber)]] = "+25 ML";
+    //         folder_descriptions[$item[folder (holographic fractal)]] = "+4 all res";
+    //         folder_descriptions[$item[folder (barbarian)]] = "stinging damage";
+    //         folder_descriptions[$item[folder (rainbow unicorn)]] = "prismatic stinging damage";
+    //         folder_descriptions[$item[folder (Seawolf)]] = "-pressure penalty";
+    //         folder_descriptions[$item[folder (dancing dolphins)]] = "+50% item (underwater)";
+    //         folder_descriptions[$item[folder (catfish)]] = "+15 familiar weight (underwater)";
+    //         folder_descriptions[$item[folder (tranquil landscape)]] = "15 DR / 15 HP & MP regen";
+    //         folder_descriptions[$item[folder (owl)]] = "+500% item (dreadsylvania)";
+    //         folder_descriptions[$item[folder (Stinky Trash Kid)]] = "passive stench damage";
+    //         folder_descriptions[$item[folder (sports car)]] = "+5 adv";
+    //         folder_descriptions[$item[folder (sportsballs)]] = "+5 PVP fights";
+    //         folder_descriptions[$item[folder (heavy metal)]] = "+5 familiar weight";
+    //         folder_descriptions[$item[folder (Yedi)]] = "+50% spell damage";
+    //         folder_descriptions[$item[folder (KOLHS)]] = "+50% item (KOLHS)";
+            
+    //         foreach s in $slots[folder1,folder2,folder3]
+    //         {
+    //             item folder = s.equipped_item();
+    //             if (folder == $item[none]) continue;
+                
+    //             if (folder_descriptions contains folder)
+    //                 description.listAppend(folder_descriptions[folder]);
+    //         }
+    //         if (description.count() > 0)
+    //             line = description.listJoinComponents(" / ");
+    //     }
+    //     pullable_item_list.listAppend(GPItemMake($item[over-the-shoulder folder holder], line, 1));
+    // }
+    
+    // As with folder holder, this just isn't really a great pull anymore. Minor back slot is just not useful at all.
+
+    // if (!__misc_state["familiars temporarily blocked"] && ($item[protonic accelerator pack].available_amount() == 0 || $familiar[machine elf].familiar_is_usable())) //if you have a machine elf, it might be worth pulling a bjorn with a protonic pack anyways
+    // {
+    //     if ($item[Buddy Bjorn].storage_amount() > 0)
+    //         pullable_item_list.listAppend(GPItemMake($item[Buddy Bjorn], "+10ML/+lots MP hat|or +item/+init/+meat/etc", 1));
+    //     else if ($item[buddy bjorn].available_amount() == 0)
+    //         pullable_item_list.listAppend(GPItemMake($item[crown of thrones], "+10ML/+lots MP hat|or +item/+init/+meat/etc", 1));
+    // }
+
+    // At best, this is +5 fam weight; not worth a pull at all.
+	// if ($item[operation patriot shield].item_is_usable())
+    //         pullable_item_list.listAppend(GPItemMake($item[operation patriot shield], "+america", 1));
+    //     pullable_item_list.listAppend(GPItemMake($item[the crown of ed the undying], "Various in-run modifiers. (init, HP, ML/item/meat/etc)", 1));
+    // }
+
+	//pullable_item_list.listAppend(GPItemMake($item[haiku katana], "?", 1));
+	// if ($item[bottle-rocket crossbow].item_is_usable())
+    //     pullable_item_list.listAppend(GPItemMake($item[bottle-rocket crossbow], "?", 1));
+
+    // This never showed up because it had an added false in the condition. I am commenting it out
+    //   because I don't think anyone in unrestricted would ever want to do this?
+	
+    // if (!have_super_fairy && my_path().id != PATH_HEAVY_RAINS)
+	// {
+	// 	if (familiar_is_usable($familiar[fancypants scarecrow]))
+	// 		pullable_item_list.listAppend(GPItemMake($item[spangly mariachi pants], "2x fairy on fancypants scarecrow", 1));
+	// 	else if (familiar_is_usable($familiar[mad hatrack]))
+	// 		pullable_item_list.listAppend(GPItemMake($item[spangly sombrero], "2x fairy on mad hatrack", 1));
+	// }
+
+    // These all suck now lol
+	//pullable_item_list.listAppend(GPItemMake($item[jewel-eyed wizard hat], "a wizard is you!", 1));
+	//pullable_item_list.listAppend(GPItemMake($item[origami riding crop], "+5 stats/fight, but only if the monster dies quickly", 1)); //not useful?
+	//pullable_item_list.listAppend(GPItemMake($item[plastic pumpkin bucket], "don't know", 1)); //not useful?
+	//pullable_item_list.listAppend(GPItemMake($item[packet of mayfly bait], "why let it go to waste?", 1));
 
 	pullable_item_list.listAppend(GPItemMake($item[loathing legion knife], "?", 1));
 
@@ -277,9 +396,6 @@ void generatePullList(Checklist [int] checklists)
 		if (my_path().id != PATH_ZOMBIE_SLAYER) // can't use due to MP cost
 			pullable_item_list.listAppend(GPItemMake($item[mafia middle finger ring], "one free runaway/banish/day", 1));
     }
-	//pullable_item_list.listAppend(GPItemMake($item[haiku katana], "?", 1));
-	// if ($item[bottle-rocket crossbow].item_is_usable())
-    //     pullable_item_list.listAppend(GPItemMake($item[bottle-rocket crossbow], "?", 1));
 	if ($item[jekyllin hide belt].item_is_usable())
         pullable_item_list.listAppend(GPItemMake($item[jekyllin hide belt], "+variable% item", 3));
     
@@ -306,17 +422,7 @@ void generatePullList(Checklist [int] checklists)
                     pullable_item_list.listAppend(GPItemMake($item[cane-mail shirt], "+20ML shirt", 1));
         }
     }
-    if (__quest_state["Level 10"].mafia_internal_step >= 8)
-    {
-    	if (__quest_state["Level 10"].mafia_internal_step == 8 && $item[amulet of extreme plot significance].available_amount() == 0)
-        {
-        	pullable_item_list.listAppend(GPItemMake($item[amulet of extreme plot significance], "Speeds up castle basement.", 1));
-        }
-        if (!__quest_state["Level 10"].finished && $item[mohawk wig].available_amount() == 0 && (!lookupSkill("Comprehensive Cartography").skill_is_usable() || $item[model airship].available_amount() == 0))
-        {
-            pullable_item_list.listAppend(GPItemMake($item[mohawk wig], "Speeds up top floor of castle.", 1));
-        }
-    }
+
     if ($item[Clara's Bell].item_is_usable())
 	    pullable_item_list.listAppend(GPItemMake($item[Clara's Bell], "Forces a non-combat, once/day.", 1));
     if (combat_items_usable && $item[replica bat-oomerang].item_is_usable())
@@ -331,23 +437,6 @@ void generatePullList(Checklist [int] checklists)
 	boolean have_super_fairy = false;
 	if ((familiar_is_usable($familiar[fancypants scarecrow]) && $item[spangly mariachi pants].available_amount() > 0) || (familiar_is_usable($familiar[mad hatrack]) && $item[spangly sombrero].available_amount() > 0))
 		have_super_fairy = true;
-    
-    // This never showed up because it had an added false in the condition. I am commenting it out
-    //   because I don't think anyone in unrestricted would ever want to do this?
-	
-    // if (!have_super_fairy && my_path().id != PATH_HEAVY_RAINS)
-	// {
-	// 	if (familiar_is_usable($familiar[fancypants scarecrow]))
-	// 		pullable_item_list.listAppend(GPItemMake($item[spangly mariachi pants], "2x fairy on fancypants scarecrow", 1));
-	// 	else if (familiar_is_usable($familiar[mad hatrack]))
-	// 		pullable_item_list.listAppend(GPItemMake($item[spangly sombrero], "2x fairy on mad hatrack", 1));
-	// }
-
-    // These all suck now lol
-	//pullable_item_list.listAppend(GPItemMake($item[jewel-eyed wizard hat], "a wizard is you!", 1));
-	//pullable_item_list.listAppend(GPItemMake($item[origami riding crop], "+5 stats/fight, but only if the monster dies quickly", 1)); //not useful?
-	//pullable_item_list.listAppend(GPItemMake($item[plastic pumpkin bucket], "don't know", 1)); //not useful?
-	//pullable_item_list.listAppend(GPItemMake($item[packet of mayfly bait], "why let it go to waste?", 1));
 	
 	if ($items[greatest american pants, navel ring of navel gazing].available_amount() + pullable_amount($item[greatest american pants]) + pullable_amount($item[navel ring of navel gazing]) == 0)
 		pullable_item_list.listAppend(GPItemMake($item[peppermint parasol], "free runaways", 1));

--- a/Source/relay/TourGuide/Quests/Spookyraven Lights Out.ash
+++ b/Source/relay/TourGuide/Quests/Spookyraven Lights Out.ash
@@ -129,7 +129,7 @@ void QSpookyravenLightsOutGenerateEntry(ChecklistEntry [int] task_entries, Check
             available_questlines.listAppend("Elizabeth");
         if (available_questlines.count() > 0)
         {
-            optional_task_entries.listAppend(ChecklistEntryMake("__half Lights Out", "", ChecklistSubentryMake("Lights Out in " + pluralise(turns_until_next_lights_out, "adventure", "adventures"), "", available_questlines.listJoinComponents(",", "and") + " quest " + (available_questlines.count() > 1 ? "lines" : "line") + "."), (from_task ? 5 : 8)).ChecklistEntrySetIDTag("Manor lights out prediction")); //difference if they come from task or not?
+            optional_task_entries.listAppend(ChecklistEntryMake("__half Lights Out", "", ChecklistSubentryMake("Lights Out in " + pluralise(turns_until_next_lights_out, "adventure", "adventures"), "", available_questlines.listJoinComponents(", ", "and") + " quest " + (available_questlines.count() > 1 ? "lines" : "line") + "."), (from_task ? 5 : 8)).ChecklistEntrySetIDTag("Manor lights out prediction")); //difference if they come from task or not?
         }
     }
     

--- a/Source/relay/TourGuide/Sections/Messages.ash
+++ b/Source/relay/TourGuide/Sections/Messages.ash
@@ -837,7 +837,7 @@ string generateRandomMessage()
         }
         while (commands.count() > 6)
             remove commands[commands.listKeyForIndex(0)];
-        set_property("__voices", commands.listJoinComponents(",") + "|"); //we add an ending sentinel because set_property() will remove ";" if it's at the end of the string. set_property() is not guaranteed to keep data integrity
+        set_property("__voices", commands.listJoinComponents(", ") + "|"); //we add an ending sentinel because set_property() will remove ";" if it's at the end of the string. set_property() is not guaranteed to keep data integrity
         
         random_messages.listClear();
         

--- a/Source/relay/TourGuide/Sets/Active Banishes.ash
+++ b/Source/relay/TourGuide/Sets/Active Banishes.ash
@@ -44,7 +44,7 @@ string DescribeThisBanish(Banish b) {
     int turnsSinceBanish = my_turncount() - banishTurn;
     int turnsOfBanishLeft = banishLength - turnsSinceBanish;
 
-    if (source = "Bowl a Curveball") {
+    if (source == "Bowl a Curveball") {
         turnsOfBanishLeft = get_property_int("cosmicBowlingBallReturnCombats");
     }
 

--- a/Source/relay/TourGuide/Sets/Active Banishes.ash
+++ b/Source/relay/TourGuide/Sets/Active Banishes.ash
@@ -166,7 +166,7 @@ void ActiveBanishesList(ChecklistEntry [int] resource_entries)
     phylum phylumBanished = $phylum[none];
     int monsterCount = 0;
 
-	if (phylaResult.length() > 0) {
+	if (phylaResult.count() > 0) {
 		name = "Current Phyla Banished";
 
         int screechCharge = get_property_int("screechCombats");

--- a/Source/relay/TourGuide/Sets/Active Banishes.ash
+++ b/Source/relay/TourGuide/Sets/Active Banishes.ash
@@ -44,6 +44,10 @@ string DescribeThisBanish(Banish b) {
     int turnsSinceBanish = my_turncount() - banishTurn;
     int turnsOfBanishLeft = banishLength - turnsSinceBanish;
 
+    if (source = "Bowl a Curveball") {
+        turnsOfBanishLeft = get_property_int("cosmicBowlingBallReturnCombats");
+    }
+
     if (turnsOfBanishLeft < 0) {
         return "";
     }
@@ -73,7 +77,7 @@ string DescribeThisBanish(BanishedPhylum b) {
 
     int turnsSinceBanish = my_turncount() - banishTurn;
     int turnsOfBanishLeft = banishLength - turnsSinceBanish;
-
+    
     if (turnsOfBanishLeft < 0) {
         return "";
     }

--- a/Source/relay/TourGuide/Sets/Fax.ash
+++ b/Source/relay/TourGuide/Sets/Fax.ash
@@ -15,20 +15,20 @@ string [int] SFaxGeneratePotentialFaxes(boolean suggest_less_powerful_faxes, boo
     
     if (__misc_state["in run"])
     {
-        
-        if (!familiar_is_usable($familiar[angry jung man]))
-        {
-            //Can't pull for jar of psychoses, no jung man...
-            //It's time for a g-g-g-ghost! zoinks!
-            if (!__quest_state["Level 13"].state_boolean["digital key used"] && ($item[digital key].available_amount() + creatable_amount($item[digital key])) == 0)
-            {
-                string line = "Ghost - only if you can copy it.";
-                if (can_arrow)
-                    line += " (arrow?)";
-                line += "|*5 white pixels drop per ghost, speeds up digital key. Run +150% item.";
-                potential_faxes.listAppend(line);
-            }
-        }
+        // Remove Ghost because it is now bad now that you don't actually need white pixels.
+        // if (!familiar_is_usable($familiar[angry jung man]))
+        // {
+        //     //Can't pull for jar of psychoses, no jung man...
+        //     //It's time for a g-g-g-ghost! zoinks!
+        //     if (!__quest_state["Level 13"].state_boolean["digital key used"] && ($item[digital key].available_amount() + creatable_amount($item[digital key])) == 0)
+        //     {
+        //         string line = "Ghost - only if you can copy it.";
+        //         if (can_arrow)
+        //             line += " (arrow?)";
+        //         line += "|*5 white pixels drop per ghost, speeds up digital key. Run +150% item.";
+        //         potential_faxes.listAppend(line);
+        //     }
+        // }
         //sleepy mariachi
         if (familiar_is_usable($familiar[fancypants scarecrow]) || familiar_is_usable($familiar[mad hatrack]))
         {

--- a/Source/relay/TourGuide/Settings.ash
+++ b/Source/relay/TourGuide/Settings.ash
@@ -1,5 +1,5 @@
 //These settings are for development. Don't worry about editing them.
-string __version = "2.1.0";
+string __version = "2.2.0"; // pushed to 2.2.0 on new pull list refactor
 
 //Path and name of the .js file. In case you change either.
 string __javascript = "TourGuide/TourGuide.js";

--- a/Source/relay/TourGuide/State.ash
+++ b/Source/relay/TourGuide/State.ash
@@ -476,7 +476,22 @@ void setUpState()
 	//monster.monster_initiative() is usually what you need, but just in case:
     __misc_state_float["init ML penalty"] = monsterExtraInitForML(monster_level_adjustment_ignoring_plants());
 
-	
+    // Make a state variable re: zap wand ownership
+    __misc_state["zap wand owned"] = false;
+
+    item zap_wand_owned;
+
+    if (true) {
+        zap_wand_owned = $item[none];
+        foreach wand in $items[aluminum wand,ebony wand,hexagonal wand,marble wand,pine wand] {
+            if (wand.available_amount() > 0) {
+                zap_wand_owned = wand;
+                break;
+            }
+        }
+    }
+
+    if (zap_wand_owned != $item[none]) __misc_state["zap wand owned"] = true;
 	
 	int ngs_needed = 0;
 	

--- a/Source/relay/TourGuide/Support/Banishers.ash
+++ b/Source/relay/TourGuide/Support/Banishers.ash
@@ -97,8 +97,8 @@ static
 	__banish_source_length["system sweep"] = -1;
 	__banish_source_length["feel hatred"] = 50;
 	__banish_source_length["show your boring familiar pictures"] = 100;
+	__banish_source_length["bowl a curveball"] = 5;
 	__banish_source_length["patriotic screech"] = 100;
-	__banish_source_length["bowl a curveball"] = get_property_int("cosmicBowlingBallReturnCombats");
 	__banish_source_length["monkey slap"] = 1234567; // this, for some reason, was not properly respecting the reset condition. so imma just do this to hopefully solve it.
     
     int [string] __banish_simultaneous_limit;
@@ -145,6 +145,7 @@ Banish [int] BanishesActive()
         b.banish_turn_length = 0;
         if (__banish_source_length contains b.banish_source.to_lower_case())
             b.banish_turn_length = __banish_source_length[b.banish_source.to_lower_case()];
+            if (b.banish_source == "bowl a curveball") b.banish_turn_length = get_property_int("cosmicBowlingBallReturnCombats");
         if (b.banish_source == "batter up!" || b.banish_source == "deathchucks" || b.banish_source == "dirty stinkbomb" || b.banish_source == "nanorhino" || b.banish_source == "spooky music box mechanism" || b.banish_source == "ice hotel bell" || b.banish_source == "beancannon" || b.banish_source == "monkey slap")
             b.custom_reset_conditions = "rollover";
         if (b.banish_source == "ice house" && (!$item[ice house].is_unrestricted() || in_bad_moon())) //not relevant


### PR DESCRIPTION
not done yet, will be working on this through the weekend. goal is to re-organize the `Pulls.ash` file and finally address #40. in the first push i've used carew's code to teach the recommender that you can only pull 1 of anything on the list. i've also added legendary cookbookbat food and removed a few stubs/coerced-false recommendations leftover from ezan. 

i have made a commented list of everything i'm planning on adding, but before i do that, i am probably going to re-order some things; my initial thought is to have the first section of the file cover >3 turn pulls, next section covers quest-related pulls, next section is the marginals, final section is turnbloat. this is (slightly) less user friendly for the beginner ascender but i think overall it fits with the ethos of tourguide and will at least apply a slight bit more order/structure to the lil guy. 