### PR TITLE
november update; initial jill + leaves support

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2016/Clan Floundry.ash
+++ b/Source/relay/TourGuide/Items of the Month/2016/Clan Floundry.ash
@@ -26,8 +26,6 @@ void IOTMClanFloundryGenerateResource(ChecklistEntry [int] resource_entries)
     {
         //Bass clarinet: -10% combat, 1h ranged weapon, +100% moxie, -3 MP skill cost, +50 ranged damage, 10 white pixels
         string line = "-10% combat, +100% moxie, -3 MP skill cost, +50 ranged damage";
-        if (!__quest_state["Level 13"].state_boolean["digital key used"] && ($item[digital key].available_amount() + creatable_amount($item[digital key])) == 0)
-            line += ", 10 white pixels";
         equipment.listAppend(listMake("Bass clarinet", "ranged weapon", line));
         //Fish hatchet: -10% combat, 1h axe, +100% muscle, +5 familiar weight, +50 weapon damage, +5 bridge progress
         line = "-10% combat, +100% muscle, +5 familiar weight, +50 weapon damage";

--- a/Source/relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash
@@ -72,7 +72,7 @@ void IOTMTinyStillsuitGenerateTasks(ChecklistEntry [int] task_entries, Checklist
 	title = HTMLGenerateSpanFont(sweatAdvs + " adv stillsuit sweat booze", "purple");
 	
 	// However, if the user is in a path where they can't use stillsuit or cannot drink the distillate right now, do not show this supernag.
-	if (!inStillsuitPath || !canGuzzleSweat) continue;
+	if (!inStillsuitPath || !canGuzzleSweat) return;
 
 	if (__misc_state["in run"] && sweatAdvs > 6) {
 		task_entries.listAppend(ChecklistEntryMake("__item tiny stillsuit", url, ChecklistSubentryMake(title, description), -11).ChecklistEntrySetIDTag("tiny stillsuit task"));

--- a/Source/relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Tiny Stillsuit.ash
@@ -8,9 +8,15 @@ void IOTMTinyStillsuitGenerateTasks(ChecklistEntry [int] task_entries, Checklist
 	string title;
 	string [int] description;
 	string url = "inventory.php?action=distill&pwd=" + my_hash();
+
 	int sweatCalcSweat;
 	int sweatAdvs = round(to_int(get_property("familiarSweat"))**0.4);
 
+	// Adding a few conditions to turn off the supernag.
+	boolean canGuzzleSweat = (availableDrunkenness() > 0);
+	boolean inStillsuitPath = (!__misc_state["familiars temporarily blocked"] && my_path() != $path[A Shrunken Adventurer am I]);
+
+	// TODO: Turn this into an actual math function instead of an else-if lol
 	if (fam_sweat_o_meter >= 358) {
 		sweatCalcSweat = 449;
 	}
@@ -50,8 +56,9 @@ void IOTMTinyStillsuitGenerateTasks(ChecklistEntry [int] task_entries, Checklist
 		description.listAppend(HTMLGenerateSpanOfClass(fam_sweat_o_meter + "/" + sweatCalcSweat, "r_bold") + " drams of stillsuit sweat for next adventure.");
 		description.listAppend("" + HTMLGenerateSpanOfClass(sweatCalcSweat - fam_sweat_o_meter, "r_bold") + " more sweat until +1 more adventure. (" + (1+ (sweatCalcSweat - fam_sweat_o_meter)/3) + " combats on current familiar)");
 	}
-	
-	if ($item[tiny stillsuit].item_amount() == 1) {
+
+	// Still generate the "warning, not generating sweat" supernag so long as familiars aren't blocked
+	if ($item[tiny stillsuit].item_amount() == 1 && !__misc_state["familiars temporarily blocked"]) {
 		title = HTMLGenerateSpanFont("Equip the stillsuit", "purple");
 		description.listAppend("" + HTMLGenerateSpanFont("Not collecting sweat from any familiar right now.", "red") + "");
 		url = "familiar.php";
@@ -63,6 +70,10 @@ void IOTMTinyStillsuitGenerateTasks(ChecklistEntry [int] task_entries, Checklist
 		description.listAppend("" + HTMLGenerateSpanFont("Currently collecting sweat on a different familiar!", "fuchsia") + "");
     }	
 	title = HTMLGenerateSpanFont(sweatAdvs + " adv stillsuit sweat booze", "purple");
+	
+	// However, if the user is in a path where they can't use stillsuit or cannot drink the distillate right now, do not show this supernag.
+	if (!inStillsuitPath || !canGuzzleSweat) continue;
+
 	if (__misc_state["in run"] && sweatAdvs > 6) {
 		task_entries.listAppend(ChecklistEntryMake("__item tiny stillsuit", url, ChecklistSubentryMake(title, description), -11).ChecklistEntrySetIDTag("tiny stillsuit task"));
 	}

--- a/Source/relay/TourGuide/Items of the Month/2023/A Guide to Burning Leaves.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/A Guide to Burning Leaves.ash
@@ -1,0 +1,185 @@
+// TILE SPEC:
+//    - Remind the user to spend their leaves.
+//    - Advise the user of top leafy options.
+//    - Add leafy free fights to the freefightcombinationtag
+
+Record LeafyFight 
+{
+    int leafCost;
+    monster summonedMonster;
+    string scaling;
+    int leavesDropped;
+    string extraDrops;
+}
+
+LeafyFight LeafyFightMake(int cost, monster summonedMonster, string scaling, int leavesDropped, item itemDropped)
+{
+    LeafyFight summon;
+
+    summon.leafCost = cost;
+    summon.summonedMonster = summonedMonster;
+    summon.scaling = scaling;
+    summon.leavesDropped = leavesDropped;
+    summon.itemDropped = itemDropped;
+    
+    return summon;
+}
+
+Record LeafySummon
+{
+    int leafCost;
+    item summonedItem;
+    string description;
+    boolean meltingStatus;
+    string prefName;
+}
+
+LeafySummon LeafySummonMake(int cost, item summonedItem, string desc, boolean melts, string prefName)
+{
+    LeafySummon summon;
+
+    summon.leafCost = cost;
+    summon.summonedItem = summonedItem;
+    summon.description = desc;
+    summon.meltingStatus = melts;
+    summon.prefName = prefName;
+    
+    return summon;
+}
+
+RegisterResourceGenerationFunction("IOTMBurningLeavesGenerateResource");
+void IOTMBurningLeavesGenerateResource(ChecklistEntry [int] resource_entries)
+{
+    // Don't generate these tiles if they cannot actually use their leaves
+    if (!__iotms_usable[$item[A Guide to Burning Leaves]]) return;
+
+    string url = "campground.php?preaction=burningleaves";
+
+    // Make two tiles for spending leaves
+    item leaf = $item[inflammable leaf];
+    int leafCount = leaf.item_amount();
+    string [int] itemsDescription;
+    string [int] monstersDescription;
+
+    // To use these, if you do "aftercoreStuff[##]" it'll return true if it's in the list or false if not
+    boolean [int] aftercoreStuff = [222,1111,6666,11111];
+    boolean [int] inRunStuff = [42,43,44,66];
+
+    // Disabling in-run condition for testing
+    // if (leaf.have() && __misc_state["in run"]) {
+    if (leaf.have()) {
+
+        LeafyFight [int] leafyFights;
+        // leafyFights.listAppend(LeafyFightMake(#leafcost, $monster[leafmonster], "scaling desc", #leafdrops, "extra drops"));
+        leafyFights.listAppend(LeafyFightMake(11, $monster[flaming leaflet], "11/11/11", 4, ""));
+        leafyFights.listAppend(LeafyFightMake(111, $monster[flaming monstera], "scaling", 7, "leafy browns"));
+        leafyFights.listAppend(LeafyFightMake(666, $monster[leaviathan], "scaling boss (hard!)", 125, "leafy browns"));
+
+        LeafySummon [int] leafySummons;
+        // leafySummons.listAppend(LeafySummonMake(#leafcost, $item[leafsummon], "tile desc", t/f(melts), "name of summon check pref"));
+        leafySummons.listAppend(LeafySummonMake(37, $item[autumnic bomb], "potion; prismatic stinging (25 turns)", false, ""));
+        leafySummons.listAppend(LeafySummonMake(42, $item[impromptu torch], "weapon; +2 mus/fight", true, ""));
+        leafySummons.listAppend(LeafySummonMake(43, $item[flaming fig leaf], "pants; +2 mox/fight", true, ""));
+        leafySummons.listAppend(LeafySummonMake(44, $item[smoldering drape], "cape; +2 mys/fight, +20% stat", true, ""));
+        leafySummons.listAppend(LeafySummonMake(50, $item[distilled resin], "potion; generate +1 leaf/fight (100 turns)", false, ""));
+        leafySummons.listAppend(LeafySummonMake(66, $item[autumnal aegis], "shield; +250 DA, +2 all res", false, ""));
+        leafySummons.listAppend(LeafySummonMake(69, $item[lit leaf lasso], "combat item; lasso leaf freebies for +1 free fight", false, "_leafLassosCrafted"));
+        leafySummons.listAppend(LeafySummonMake(74, $item[forest canopy bed], "bed; +5 free rests, stats via rests", false, ""));
+        leafySummons.listAppend(LeafySummonMake(99, $item[autumnic balm], "potion; +2 all res (100 turns)", false, ""));
+        leafySummons.listAppend(LeafySummonMake(222, $item[day shortener], "spend 5 turns for a +turn item", false, "_leafDayShortenerCrafted"));
+        leafySummons.listAppend(LeafySummonMake(1111, $item[coping juice], "copium for the masses", false, ""));
+        leafySummons.listAppend(LeafySummonMake(6666, $item[smoldering leafcutter ant egg], "mosquito & leaves familiar", false, "_leafAntEggCrafted"));
+        leafySummons.listAppend(LeafySummonMake(11111, $item[super-heated leaf], "burn leaves into your skiiiin", false, ""));
+
+        // Make a big summons table for a leaf summoning tile 
+        string [int][int] summonOptions;
+
+        // Header for the item summons table
+        if (true) 
+        {
+            string [int] option;
+            option.listAppend("cost");
+            option.listAppend("item");
+            option.listAppend("description");
+            foreach key, s in option
+            {
+                option[key] = HTMLGenerateSpanOfClass(s, "r_bold");
+            }
+            summonOptions.listAppend(option);
+        }
+
+        // Populate the table
+        foreach key, summon in leafySummons 
+        {
+            // Adding some skip conditions for certain stuff
+            if (__misc_state["in run"] && aftercoreStuff[summon.leafCost]) continue; 
+            if (!__misc_state["in run"] && inRunStuff[summon.leafCost]) continue;
+
+            // Run pref checks & do not generate a row if you can't summon it
+            boolean userCanSummon;
+
+            switch (summon.prefName) {
+                case "":
+                    userCanSummon = true;
+                case "_leafLassosCrafted":
+                    userCanSummon = get_property_int("_leafLassosCrafted") < 3;
+                default:
+                    userCanSummon = get_property_boolean(summon.prefName);
+            }
+
+            if (!userCanSummon) continue;
+
+            // Set the color to gray if you don't have enough leaves
+            boolean hasEnoughLeaves = leafCount > summon.leafCost;
+            string rowColor = hasEnoughLeaves ? "black" : "gray";
+
+            // Add smaller melting tag to description, if it's melting
+            string summonDesc = summon.description;
+            if (summon.meltingStatus) 
+                summonDesc += HTMLGenerateSpanFont("(melting)", "0.9em");
+
+            string [int] option;
+            // add cost
+            option.listAppend(summon.leafCost);
+            option.listAppend(summon.summonedItem.to_string())
+            option.listAppend(summonDesc)
+            foreach key, s in option 
+            {
+                option[key] = HTMLGenerateSpanFont(s, rowColor);
+            }
+            summonOptions.listAppend(options);
+        }
+        itemsDescription.listPrepend(HTMLGenerateSimpleTableLines(summonOptions));
+
+        resource_entries.listAppend(ChecklistEntryMake("__item inflammable leaf", url, ChecklistSubentryMake(pluralise(leafCount, "leaf to spend", "leaves to spend"), "", itemsDescription), 13).ChecklistEntrySetIDTag("Burning leaf item summons"));
+
+    }
+    
+    // Make a free fights tile for available free leaf fights
+    int fightsRemaining = clampi(5 - get_property_int("_leafMonstersFought"), 0, 5);
+    
+    string [int] description;
+    ChecklistSubentry [int] subentries;
+
+    if (fightsRemaining > 0) {
+        
+        if (leafCount > 111*fightsRemaining) {
+            description.listAppend("Have enough leaves for "+fightsRemaining+" flaming monstera");
+        }
+        else if (leafCount > 11*fightsRemaining) {
+            description.listAppend("Have enough leaves for "+fightsRemaining+" leaflets");
+        }
+        else if (leafCount > 8*fightsRemaining) {
+            description.listAppend("Have enough leaves, if you let the leaflets drop their bounty!");
+        }
+        else {
+            description.listAppend(HTMLGenerateSpanFont("Don't have enough leaves to fight your leaflets... get more!", "red"))
+        }
+
+        subentries.listAppend(ChecklistSubentryMake(pluralise(fightsRemaining, "free flaming leaflet fight", "free flaming leaflet fights"), "", description));
+        TagGroup tags;
+        tags.id = "Burning Leaves free fights";
+        tags.combination = "daily free fight";
+        resource_entries.listAppend(ChecklistEntryMake("__item tied-up flaming leaflet", url, subentries, tags, 0));
+    }
+}

--- a/Source/relay/TourGuide/Items of the Month/2023/A Guide to Burning Leaves.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/A Guide to Burning Leaves.ash
@@ -90,7 +90,7 @@ void IOTMBurningLeavesGenerateResource(ChecklistEntry [int] resource_entries)
         leafySummons.listAppend(LeafySummonMake(44, $item[smoldering drape], "cape; +2 mys/fight, +20% stat", true, ""));
         leafySummons.listAppend(LeafySummonMake(50, $item[distilled resin], "potion; generate +1 leaf/fight (100 turns)", false, ""));
         leafySummons.listAppend(LeafySummonMake(66, $item[autumnal aegis], "shield; +250 DA, +2 all res", false, ""));
-        leafySummons.listAppend(LeafySummonMake(69, $item[lit leaf lasso], "combat item; lasso leaf freebies for +1 free fight", false, "_leafLassosCrafted"));
+        leafySummons.listAppend(LeafySummonMake(69, $item[lit leaf lasso], "combat item; lasso leaf freebies for extra end-of-combat triggers", false, "_leafLassosCrafted"));
         leafySummons.listAppend(LeafySummonMake(74, $item[forest canopy bed], "bed; +5 free rests, stats via rests", false, ""));
         leafySummons.listAppend(LeafySummonMake(99, $item[autumnic balm], "potion; +2 all res (100 turns)", false, ""));
         leafySummons.listAppend(LeafySummonMake(222, $item[day shortener], "spend 5 turns for a +turn item", false, "_leafDayShortenerCrafted"));
@@ -175,6 +175,15 @@ void IOTMBurningLeavesGenerateResource(ChecklistEntry [int] resource_entries)
             if (summon.meltingStatus) 
                 summonDesc += HTMLGenerateSpanFont(" (melting)", "gray", "0.7em");
 
+            // Hide aftercore stuff while in-run, and visa versa
+            if (__misc_state["in run"]) {
+                if (aftercoreStuff[summon.leafCost]) continue;
+            } 
+            
+            if (!__misc_state["in run"]) {
+                if (inRunStuff[summon.leafCost]) continue;
+            }
+
             string [int] option;
             // add cost
             option.listAppend(summon.leafCost);
@@ -246,7 +255,7 @@ void IOTMBurningLeavesGenerateResource(ChecklistEntry [int] resource_entries)
 
             monstersDescription.listAppend(HTMLGenerateSimpleTableLines(fightOptions));
             if (leafCount > 111*fightsRemaining) {
-                monstersDescription.listAppend("With your "+pluralise(leafCount, "leaf", "leaves")+", you can summon <b>"+fightsRemaining+" monstera</b>, for 5 scaling fights");
+                monstersDescription.listAppend("With your "+pluralise(leafCount, "leaf", "leaves")+", you can summon <b>"+fightsRemaining+" monstera</b>, for scaling fights");
             }
             else if (leafCount > 11*fightsRemaining) {
                 monstersDescription.listAppend("With your "+pluralise(leafCount, "leaf", "leaves")+", you can summon <b>"+fightsRemaining+" leaflets</b>, for familiar turns");
@@ -266,23 +275,24 @@ void IOTMBurningLeavesGenerateResource(ChecklistEntry [int] resource_entries)
     
     // Make a free fights combo tag for available free leaf fights
     int fightsRemaining = clampi(5 - get_property_int("_leafMonstersFought"), 0, 5);
+    int leafletsUserCanSummon = leafCount/11;
     
     string [int] description;
     ChecklistSubentry [int] subentries;
 
     if (fightsRemaining > 0) {
         
-        if (leafCount > 111*fightsRemaining) {
+        if (leafCount >= 111*fightsRemaining) {
             description.listAppend("Have enough leaves for "+fightsRemaining+" flaming monstera");
         }
-        else if (leafCount > 11*fightsRemaining) {
+        else if (leafCount >= 11*fightsRemaining) {
             description.listAppend("Have enough leaves for "+fightsRemaining+" leaflets");
         }
-        else if (leafCount > 8*fightsRemaining) {
+        else if (leafCount >= 8*fightsRemaining) {
             description.listAppend("Have enough leaves, if you let the leaflets drop their bounty!");
         }
         else {
-            description.listAppend(HTMLGenerateSpanFont("Don't have enough leaves to fight your leaflets... get more!", "red"));
+            description.listAppend(HTMLGenerateSpanFont("Can summon "+leafletsUserCanSummon+" of your "+fightsRemaining+" leaflets... get more leaves!", "orange"));
         }
 
         subentries.listAppend(ChecklistSubentryMake(pluralise(fightsRemaining, "free flaming leaflet fight", "free flaming leaflet fights"), "", description));

--- a/Source/relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash
@@ -33,10 +33,10 @@ void IOTMJillv2GenerateResource(ChecklistEntry [int] resource_entries)
 
     string [int] description;
     if (mapsDropped == 0) {
-        description.listAppend("You haven't gotten a map to halloween town yet! Try using your Jill for a map at ~"+estimatedMapProbability+"% chance, or approximately "+round(turnsToMap,2)+" turns.");
+        description.listAppend("You haven't gotten a map to halloween town yet! Try using your Jill for a map at ~"+estimatedMapProbability+"% chance, or approximately "+round(turnsToMap,1)+" turns.");
     }
     else {
-        description.listAppend("You have a map; the next map is at a ~"+estimatedMapProbability+"% chance, or approximately "+round(turnsToMap,2)+" turns.")
+        description.listAppend("You have a map; the next map is at a ~"+estimatedMapProbability+"% chance, or approximately "+round(turnsToMap,1)+" turns.");
     }
     
 	int habitatRecallsLeft = clampi(3 - get_property_int("_monsterHabitatsRecalled"), 0, 3);

--- a/Source/relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash
@@ -37,7 +37,8 @@ void IOTMJillv2GenerateResource(ChecklistEntry [int] resource_entries)
     if (habitatRecallsLeft > 0)
 		description.listAppend("Halloween monsters make excellent targets for <b>Recall Habitat</b> from BoFA.");
 
-    if (!get_property_boolean("ledCandleDropped")) {
+    // Adding a small exception here to not generate this if they weirdly acquired LED through other means (like casual or a pull or something)
+    if (!get_property_boolean("ledCandleDropped") && $item[LED Candle].item_amount() < 1) {
         description.listAppend("Fight a dude for an LED candle, to tune your Jill!");
     }
 

--- a/Source/relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash
@@ -1,0 +1,52 @@
+// TILE SPEC: 
+//    - Remind the user to get a halloween map. 
+//    - Remind the user to get an LED candle.
+//    - Recommend halloween monsters for habitation.
+
+// CANNOT DO YET:
+//    - Add halloween fights to freebies combination tag; need better mafia tracking...
+
+RegisterResourceGenerationFunction("IOTMJillv2GenerateResource");
+void IOTMJillv2GenerateResource(ChecklistEntry [int] resource_entries)
+{
+    familiar bigJillyStyle = lookupFamiliar("Jill-of-All-Trades");
+	if (!bigJillyStyle.familiar_is_usable()) return;
+
+	int mapsDropped = get_property_int("_mapToACandyRichBlockDrops");
+	
+	string url = "familiar.php";
+	if (bigJillyStyle == my_familiar())
+		url = "";
+  
+    // Dunno what the probs are, from my logs it looks like 30% with STEEEEEEEP dropoff?
+    //   For the purposes of assumptions I'll go with 30% odds, 5% odds, 1% odds thereafter
+    int estimatedMapProbability = 1;
+    switch (mapsDropped) {
+        case 0:
+            estimatedMapProbability = 30;
+        case 1:
+            estimatedMapProbability = 5;
+    }
+
+    // Convert to turns
+    float turnsToMap = clampf(1/(to_float(estimatedMapProbability)/100),0,1);
+
+    string [int] description;
+    if (mapsDropped == 0) {
+        description.listAppend("You haven't gotten a map to halloween town yet! Try using your Jill for a map at ~"+estimatedMapProbability+"% chance, or approximately "+round(turnsToMap,2)+" turns.");
+    }
+    else {
+        description.listAppend("You have a map; the next map is at a ~"+estimatedMapProbability+"% chance, or approximately "+round(turnsToMap,2)+" turns.")
+    }
+    
+	int habitatRecallsLeft = clampi(3 - get_property_int("_monsterHabitatsRecalled"), 0, 3);
+    if (!lookupSkill("Just the Facts").have_skill() && !__iotms_usable[$item[book of facts (dog-eared)]]) habitatRecallsLeft = 0;
+    if (habitatRecallsLeft > 0)
+		description.listAppend("Halloween monsters make excellent targets for <b>Recall Habitat</b> from BoFA.");
+
+    if (!get_property_boolean("ledCandleDropped")) {
+        description.listAppend("Fight a dude for an LED candle, to tune your Jill!");
+    }
+	
+    resource_entries.listAppend(ChecklistEntryMake("__familiar jill-of-all-trades", url, ChecklistSubentryMake("Celebrating the Jillenium", "", description)).ChecklistEntrySetIDTag("Jill of All Trades tile"));
+}

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -140,3 +140,5 @@ import "relay/TourGuide/Items of the Month/2023/2002 Catalog.ash";
 import "relay/TourGuide/Items of the Month/2023/Patriotic Eagle.ash";
 import "relay/TourGuide/Items of the Month/2023/August Scepter.ash";
 import "relay/TourGuide/Items of the Month/2023/Book of Facts.ash";
+import "relay/TourGuide/Items of the Month/2023/Jill of all Trades.ash";
+import "relay/TourGuide/Items of the Month/2023/A Guide to Burning Leaves.ash";

--- a/Source/relay/TourGuide/Quests/Level 7.ash
+++ b/Source/relay/TourGuide/Quests/Level 7.ash
@@ -204,6 +204,21 @@ void QLevel7GenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int
 
         if (evilness_removed_per_adventure != 0.0)
             turns_remaining = MAX(1, ceiling(evilness_remaining / evilness_removed_per_adventure));
+
+		// TODO: This doesn't work if the user is using a non-olfaction copy source, like nosy nose or monkey point. Need to add logic for that
+	    boolean sniffedDOL = false;
+		if (get_property_monster("olfactedMonster") == $monster[dirty old lihc]) sniffedDOL = true;
+
+		// evilness_removed_per_adventure will = 0 if all appearance rates are 0, i.e., everyone is banished.
+		//   This allows the tile to note that if DOL is olfacted and everything else is banished via phylum
+		//   silliness, you can assume the rest of the turns are DOL. Otherwise, everything is unbanished, so
+		//   you get 1.5 per turn (average of all 4 monsters). 
+		if (evilness_removed_per_adventure == 0.0)
+		{
+			if (sniffedDOL) turns_remaining = MAX(1, ceiling(evilness_remaining / 3.0));
+			if (!sniffedDOL) turns_remaining = MAX(1, ceiling(evilness_remaining / 1.5));
+
+		}
         
 		if (evilness > CYRPT_BOSS_EVILNESS + 1 && (appearance_rates[$monster[slick lihc]] > 0.0 || appearance_rates[$monster[senile lihc]] > 0.0))
         {

--- a/Source/relay/TourGuide/Sets/Familiars.ash
+++ b/Source/relay/TourGuide/Sets/Familiars.ash
@@ -35,7 +35,8 @@ void SFamiliarsGenerateEntry(ChecklistEntry [int] task_entries, ChecklistEntry [
         if (!__quest_state["Level 12"].state_boolean["Nuns Finished"] && have_outfit_components("Frat Warrior Fatigues") && have_outfit_components("War Hippy Fatigues")) //brigand trick
             potential_targets.listAppend("brigand");
         
-        if (!familiar_is_usable($familiar[angry jung man]) && in_hardcore() && !__quest_state["Level 13"].state_boolean["digital key used"] && ($item[digital key].available_amount() + creatable_amount($item[digital key])) == 0 && __misc_state["fax equivalent accessible"])
+        // Adding KoE check to the romantic arrow check for a ghost monster, since this is only useful in KoE now.
+        if (!familiar_is_usable($familiar[angry jung man]) && in_hardcore() && my_path().id == PATH_KINGDOM_OF_EXPLOATHING && !__quest_state["Level 13"].state_boolean["digital key used"] && ($item[digital key].available_amount() + creatable_amount($item[digital key])) == 0 && __misc_state["fax equivalent accessible"])
             potential_targets.listAppend("ghost");
         
         if (__misc_state["in run"] && ($items[bricko eye brick,bricko airship,bricko bat,bricko cathedral,bricko elephant,bricko gargantuchicken,bricko octopus,bricko ooze,bricko oyster,bricko python,bricko turtle,bricko vacuum cleaner].available_amount() > 0 || $skill[summon brickos].skill_is_usable()))

--- a/Source/relay/TourGuide/Sets/Olfaction.ash
+++ b/Source/relay/TourGuide/Sets/Olfaction.ash
@@ -55,8 +55,10 @@ void SOlfactionGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [
             location_wanted_monster[$location[The Haunted Pantry]] = $monster[drunken half-orc hobo];
         }
         location_wanted_monster[$location[fear man's level]] = $monster[morbid skull];
-        if ($item[digital key].available_amount() == 0 && !__quest_state["Level 13"].state_boolean["digital key used"] && $item[white pixel].available_amount() + $item[white pixel].creatable_amount() < 27)
-            location_wanted_monster[$location[8-bit realm]] = $monster[Blooper];
+
+        // RIP to my boy, the blooper
+        // if ($item[digital key].available_amount() == 0 && !__quest_state["Level 13"].state_boolean["digital key used"] && $item[white pixel].available_amount() + $item[white pixel].creatable_amount() < 27)
+        //     location_wanted_monster[$location[8-bit realm]] = $monster[Blooper];
         
         
         if (!__quest_state["Level 11 Pyramid"].finished && olfacted_monster != $monster[tomb servant])

--- a/Source/relay/TourGuide/Settings.ash
+++ b/Source/relay/TourGuide/Settings.ash
@@ -1,5 +1,5 @@
 //These settings are for development. Don't worry about editing them.
-string __version = "2.2.0"; // pushed to 2.2.0 on new pull list refactor
+string __version = "2.2.1"; // pushed to 2.2.1 on jill/leaves tiles
 
 //Path and name of the .js file. In case you change either.
 string __javascript = "TourGuide/TourGuide.js";

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -31,7 +31,7 @@ void initialiseIOTMsUsable()
     if (my_path().id != PATH_ACTUALLY_ED_THE_UNDYING)
     {
         //Campground items:
-        foreach it in $items[source terminal, haunted doghouse, Witchess Set, potted tea tree, portable mayo clinic, Little Geneticist DNA-Splicing Lab, cornucopia]
+        foreach it in $items[source terminal, haunted doghouse, Witchess Set, potted tea tree, portable mayo clinic, Little Geneticist DNA-Splicing Lab, cornucopia, A Guide to Burning Leaves]
         {
             if (__campground[it] > 0)
                 __iotms_usable[it] = true;

--- a/Source/relay/TourGuide/Support/Strings.ash
+++ b/Source/relay/TourGuide/Support/Strings.ash
@@ -1,12 +1,12 @@
 import "relay/TourGuide/Support/Math.ash"
 import "relay/TourGuide/Support/List.ash"
 
-buffer to_buffer(string str)
-{
-	buffer result;
-	result.append(str);
-	return result;
-}
+// buffer to_buffer(string str)
+// {
+// 	buffer result;
+// 	result.append(str);
+// 	return result;
+// }
 
 buffer copyBuffer(buffer buf)
 {


### PR DESCRIPTION
the tiles aren't remotely done yet, but wanted to push some initial stabs at leaf/jill support.

for jill all i want is a tile with some rough math on the % chance of map, and a note to BOFA havers that the halloween fights are good for habitat recalls. it does not currently work but it's a low priority tile and is pretty close.

for leaves i added a freefight combination tag that lists out your 5 leaflet fights + a table very low in the tourguide priority list with leaf options. there is also a toggle that displays/removes some items based on in run vs aftercore status, although i turned it off for this screenshot. i also want to make a table similar to seal summoning that shows the leaf cost + leaf gain from the 3 different monsters, and notes that you can/should lasso the leaflet for +1 easy fight per day.

![image](https://github.com/loathers/TourGuide/assets/8014761/5559c61b-6fb1-448a-b1d6-5875aedb2ac2)

welcome to hear thoughts on different usage + wording + display ideas!