### PR TITLE
Basic WereProfessor support

### DIFF
--- a/Source/relay/TourGuide/Daily Resources.ash
+++ b/Source/relay/TourGuide/Daily Resources.ash
@@ -329,7 +329,7 @@ void generateDailyResources(Checklist [int] checklists)
     }
 
     //Not sure how I feel about this. It's kind of extraneous?
-    if (get_property_int("telescopeUpgrades") > 0 && !get_property_boolean("telescopeLookedHigh") && __misc_state["in run"] && my_path().id != PATH_ACTUALLY_ED_THE_UNDYING && !in_bad_moon() && my_path().id != PATH_NUCLEAR_AUTUMN && my_path().id != PATH_G_LOVER) {
+    if (get_property_int("telescopeUpgrades") > 0 && !get_property_boolean("telescopeLookedHigh") && __misc_state["in run"] && my_path().id != PATH_ACTUALLY_ED_THE_UNDYING && !in_bad_moon() && my_path().id != PATH_NUCLEAR_AUTUMN && my_path().id != PATH_G_LOVER && my_path().id != PATH_WEREPROFESSOR) {
         string [int] description;
         int percentage = 5 * get_property_int("telescopeUpgrades");
         description.listAppend("+" + (percentage == 25 ? "35% or +25" : percentage) + "% to all attributes. (10 turns)");

--- a/Source/relay/TourGuide/Paths/Paths import.ash
+++ b/Source/relay/TourGuide/Paths/Paths import.ash
@@ -22,3 +22,4 @@ import "relay/TourGuide/Paths/Grey Goo.ash";
 import "relay/TourGuide/Paths/Fall of the Dinosaurs.ash";
 import "relay/TourGuide/Paths/Avatar of Shadows over Loathing.ash";
 import "relay/TourGuide/Paths/Legacy of Loathing.ash";
+import "relay/TourGuide/Paths/WereProfessor.ash";

--- a/Source/relay/TourGuide/Paths/WereProfessor.ash
+++ b/Source/relay/TourGuide/Paths/WereProfessor.ash
@@ -22,25 +22,54 @@ void PathWereProfessorGenerateResource(ChecklistEntry [int] resource_entries)
     };
 
     string [int] scientific_locations_description;
-    scientific_locations_description.listAppend("Found in non-combat on 7th adventure in a zone.");
+    scientific_locations_description.listAppend("Found in a free non-combat on 7th adventure in a zone.");
     if ($effect[Mild-Mannered Professor].have_effect() > 0) scientific_locations_description.listAppend(HTMLGenerateSpanFont("Can only be found as a Beast", "red"));
 
-    string [int] scientific_locations_options;
+    location [int] scientific_locations_options;
     foreach key, loc in scientific_locations {
         boolean obtained_equipment = false;
         foreach nc_key, nc in loc.locationSeenNoncombats() {
             if (nc == "The Antiscientific Method") obtained_equipment = true;
         }
-        if (obtained_equipment) continue; // A smashed equipment is already acquired
+        if (!obtained_equipment) scientific_locations_options.listAppend(loc);
+    }
+
+    int scientific_locations_sort(location loc) {
+        int score = 0;
+        // +1 for each turn spent, up to 6
+        // -30 if location is inaccessible
+        // +3 if location is a quest one and the relevant quest is not yet done
+        // +10 if location is the last adventured location
+
+        int turns_spent = loc.turns_spent;
+        score += min(6, loc.turns_spent);
+        if (!loc.locationAvailable()) score -= 30;
+
+        if (loc == $location[Vanya's Castle]) score += 3; // should always get that one in the optimal scenario
+        if (loc == $location[The Castle in the Clouds in the Sky (Top Floor)] && !__quest_state["Level 10"].finished) score += 3;
+        if (loc == $location[The Hidden Hospital] && !__quest_state["Level 11 Hidden City"].state_boolean["Hospital finished"]) score += 3;
+
+        if (__last_adventure_location == loc) score += 10;
+        return score;
+    }
+
+    sort scientific_locations_options by -scientific_locations_sort(value);
+
+    string [int] loc_descriptions;
+
+    foreach key, loc in scientific_locations_options {
         int turns_spent = loc.turns_spent;
         string scientific_locations_option = loc.HTMLGenerateFutureTextByLocationAvailability();
         if (turns_spent < 6) scientific_locations_option += " - " + pluralise(6 - turns_spent, "turn left", "turns left");
         else scientific_locations_option += " - drops next turn";
-        scientific_locations_options.listAppend(scientific_locations_option);
+        loc_descriptions.listAppend(scientific_locations_option);
     }
 
     if (scientific_locations_options.count() > 0) {
-        scientific_locations_description.listAppend("Drop locations:" + scientific_locations_options.listJoinComponents("<hr>").HTMLGenerateIndentedText());
+        if (scientific_locations_options.count() > 3) {
+            scientific_locations_description.listAppend("Drop locations:" + (loc_descriptions[0] + "<hr>" + HTMLGenerateSpanOfClass(HTMLGenerateSpanOfClass(loc_descriptions.listJoinComponents("<hr>").HTMLGenerateIndentedText(), "r_tooltip_inner_class") + "All locations", "r_tooltip_outer_class")).HTMLGenerateIndentedText());
+        }
+        else scientific_locations_description.listAppend("Drop locations:" + loc_descriptions.listJoinComponents("<hr>").HTMLGenerateIndentedText());
 
         resource_entries.listAppend(ChecklistEntryMake("__item smashed scientific equipment", "", ChecklistSubentryMake("Obtain smashed scientific equipment", "", scientific_locations_description)));
     }
@@ -53,13 +82,13 @@ void PathWereProfessorGenerateResource(ChecklistEntry [int] resource_entries)
         if ($effect[Savage Beast].have_effect() > 0) smashed_equipment_description.listAppend("Wait until you are a Professor to craft stuff.");
 
         // Science-producting hats -- TODO: ignore if have all Stomach/Liver upgrades (pending Mafia support)
-        if (!have($item[biphasic molecular oculus]) && !have($item[triphasic molecular oculus])) craftable_items.listAppend("biphasic molecular oculus (for more Research Points)");
-        if (have($item[biphasic molecular oculus])) craftable_items.listAppend("triphasic molecular oculus (for more Research Points)");
+        if (!have($item[biphasic molecular oculus]) && !have($item[triphasic molecular oculus])) craftable_items.listAppend("biphasic molecular oculus (more Research Points)");
+        if (have($item[biphasic molecular oculus])) craftable_items.listAppend("triphasic molecular oculus (more Research Points)");
         // Exoskeletons
-        if (!have($item[high-tension exoskeleton]) && !have($item[ultra-high-tension exoskeleton]) && !have($item[irresponsible-tension exoskeleton])) craftable_items.listAppend("high-tension exoskeleton (to avoid attacks)");
-        if (have($item[high-tension exoskeleton])) craftable_items.listAppend("ultra-high-tension exoskeleton (to avoid attacks)");
-        if (have($item[ultra-high-tension exoskeleton])) craftable_items.listAppend("irresponsible-tension exoskeleton (to avoid attacks)");
-        // Initiative, consider if no Spring Shoes available (since they do the same thing) 
+        if (!have($item[high-tension exoskeleton]) && !have($item[ultra-high-tension exoskeleton]) && !have($item[irresponsible-tension exoskeleton])) craftable_items.listAppend("high-tension exoskeleton (avoid attacks)");
+        if (have($item[high-tension exoskeleton])) craftable_items.listAppend("ultra-high-tension exoskeleton (avoid attacks)");
+        if (have($item[ultra-high-tension exoskeleton])) craftable_items.listAppend("irresponsible-tension exoskeleton (avoid attacks)");
+        // Initiative, consider if no Spring Shoes available (since they do the same thing) and cannot equip Parka (protection from the jump)
         if (!(__misc_state["Torso aware"] && have($item[Jurassic Parka])) && !have($item[spring shoes]) && !have($item[motion sensor])) craftable_items.listAppend("motion sensor (+100% initiative accessory)");
 
         if (craftable_items.count() > 0) {

--- a/Source/relay/TourGuide/Paths/WereProfessor.ash
+++ b/Source/relay/TourGuide/Paths/WereProfessor.ash
@@ -1,0 +1,82 @@
+
+RegisterResourceGenerationFunction("PathWereProfessorGenerateResource");
+void PathWereProfessorGenerateResource(ChecklistEntry [int] resource_entries)
+{
+    if (my_path().id != PATH_WEREPROFESSOR) return;
+
+    // Smashed scientific equipment
+    location [int] scientific_locations = {
+        $location[Noob Cave],
+        $location[The Haunted Pantry],
+        $location[Madness Bakery],
+        $location[The Thinknerd Warehouse],
+        $location[Vanya's Castle],
+        $location[The Old Landfill],
+        $location[Cobb's Knob Laboratory],
+        $location[Cobb's Knob Menagerie, Level 1],
+        $location[Cobb's Knob Menagerie, Level 2],
+        $location[Cobb's Knob Menagerie, Level 3],
+        $location[The Haunted Laboratory],
+        $location[The Castle in the Clouds in the Sky (Top Floor)],
+        $location[The Hidden Hospital]
+    };
+
+    string [int] scientific_locations_description;
+    scientific_locations_description.listAppend("Found in non-combat on 7th adventure in a zone.");
+    if ($effect[Mild-Mannered Professor].have_effect() > 0) scientific_locations_description.listAppend(HTMLGenerateSpanFont("Can only be found as a Beast", "red"));
+
+    string [int] scientific_locations_options;
+    foreach key, loc in scientific_locations {
+        boolean obtained_equipment = false;
+        foreach nc_key, nc in loc.locationSeenNoncombats() {
+            if (nc == "The Antiscientific Method") obtained_equipment = true;
+        }
+        if (obtained_equipment) continue; // A smashed equipment is already acquired
+        int turns_spent = loc.turns_spent;
+        string scientific_locations_option = loc.HTMLGenerateFutureTextByLocationAvailability();
+        if (turns_spent < 6) scientific_locations_option += " - " + pluralise(6 - turns_spent, "turn left", "turns left");
+        else scientific_locations_option += " - drops next turn";
+        scientific_locations_options.listAppend(scientific_locations_option);
+    }
+
+    if (scientific_locations_options.count() > 0) {
+        scientific_locations_description.listAppend("Drop locations:" + scientific_locations_options.listJoinComponents("<hr>").HTMLGenerateIndentedText());
+
+        resource_entries.listAppend(ChecklistEntryMake("__item smashed scientific equipment", "", ChecklistSubentryMake("Obtain smashed scientific equipment", "", scientific_locations_description)));
+    }
+
+    // Owned smashed scientific equipment
+    if (have($item[smashed scientific equipment])) {
+        string [int] smashed_equipment_description;
+        string [int] craftable_items;
+
+        if ($effect[Savage Beast].have_effect() > 0) smashed_equipment_description.listAppend("Wait until you are a Professor to craft stuff.");
+
+        // Science-producting hats -- TODO: ignore if have all Stomach/Liver upgrades (pending Mafia support)
+        if (!have($item[biphasic molecular oculus]) && !have($item[triphasic molecular oculus])) craftable_items.listAppend("biphasic molecular oculus (for more Research Points)");
+        if (have($item[biphasic molecular oculus])) craftable_items.listAppend("triphasic molecular oculus (for more Research Points)");
+        // Exoskeletons
+        if (!have($item[high-tension exoskeleton]) && !have($item[ultra-high-tension exoskeleton]) && !have($item[irresponsible-tension exoskeleton])) craftable_items.listAppend("high-tension exoskeleton (to avoid attacks)");
+        if (have($item[high-tension exoskeleton])) craftable_items.listAppend("ultra-high-tension exoskeleton (to avoid attacks)");
+        if (have($item[ultra-high-tension exoskeleton])) craftable_items.listAppend("irresponsible-tension exoskeleton (to avoid attacks)");
+        // Initiative, consider if no Spring Shoes available (since they do the same thing) 
+        if (!(__misc_state["Torso aware"] && have($item[Jurassic Parka])) && !have($item[spring shoes]) && !have($item[motion sensor])) craftable_items.listAppend("motion sensor (+100% initiative accessory)");
+
+        if (craftable_items.count() > 0) {
+            smashed_equipment_description.listAppend("Consider crafting:" + craftable_items.listJoinComponents("<hr>").HTMLGenerateIndentedText());
+        }
+
+        resource_entries.listAppend(ChecklistEntryMake("__item smashed scientific equipment", "", ChecklistSubentryMake(pluralise($item[smashed scientific equipment]) + " available", "", smashed_equipment_description)));
+    }
+}
+
+RegisterTaskGenerationFunction("PathWereProfessorGenerateTasks");
+void PathWereProfessorGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+    // TODO: Professor shopping spree
+    // (a reminder to buy stuff because Beast cannot access shops)
+    // (also research stuff, but this requires Mafia support)
+
+    // TODO: supernag to remove ML if you have 26+ ML and are a Professor
+    // (start-of-combat elemental damage)
+}

--- a/Source/relay/TourGuide/Paths/WereProfessor.ash
+++ b/Source/relay/TourGuide/Paths/WereProfessor.ash
@@ -95,7 +95,7 @@ void PathWereProfessorGenerateResource(ChecklistEntry [int] resource_entries)
             smashed_equipment_description.listAppend("Consider crafting:" + craftable_items.listJoinComponents("<hr>").HTMLGenerateIndentedText());
         }
 
-        resource_entries.listAppend(ChecklistEntryMake("__item smashed scientific equipment", "", ChecklistSubentryMake(pluralise($item[smashed scientific equipment]) + " available", "", smashed_equipment_description)));
+        resource_entries.listAppend(ChecklistEntryMake("__item smashed scientific equipment", "shop.php?whichshop=wereprofessor_tinker", ChecklistSubentryMake(pluralise($item[smashed scientific equipment]) + " available", "", smashed_equipment_description)));
     }
 }
 
@@ -110,7 +110,7 @@ void PathWereProfessorGenerateTasks(ChecklistEntry [int] task_entries, Checklist
         // Too high ML!
         if (monster_level_adjustment() > 25) {
             should_nag = true;
-            professor_tips.listAppend(HTMLGenerateSpanFont(`Reduce ML, elemental monsters will kill you at the start of combat with +{monster_level_adjustment()} ML.`, "red"));
+            professor_tips.listAppend(HTMLGenerateSpanFont(`Reduce ML, elemental-aligned monsters will kill you at the start of combat with +{monster_level_adjustment()} ML.`, "red"));
         }
 
         boolean wearing_quest_outfit = false;
@@ -157,6 +157,14 @@ void PathWereProfessorGenerateTasks(ChecklistEntry [int] task_entries, Checklist
             else stuff_to_buy.listAppend("bitchin' meatcar components");
         }
         if (knoll_available() && !have($item[detuned radio])) stuff_to_buy.listAppend("detuned radio");
+        if (__quest_state["Level 11"].mafia_internal_step >= 2) { // Black Market open
+            if (__quest_state["Level 11"].mafia_internal_step == 2 && !have($item[forged identification documents])) stuff_to_buy.listAppend("forged identification documents");
+            if (!__quest_state["Level 11 Desert"].state_boolean["Black Paint Given"] && !have($item[can of black paint])) stuff_to_buy.listAppend("can of black paint");
+            if (__quest_state["Level 11 Ron"].mafia_internal_step <= 4 && !have($item[red zeppelin ticket])) stuff_to_buy.listAppend("Red Zeppelin ticket");
+        }
+        if (!have($item[UV-resistant compass])) stuff_to_buy.listAppend("UV-resistant compass");
+        if (!have($item[dinghy plans]) && !__misc_state["mysterious island available"]) stuff_to_buy.listAppend("dinghy plans");
+        if (!have($item[dingy planks]) && !__misc_state["mysterious island available"]) stuff_to_buy.listAppend("dingy planks");
         // TODO: Dramatic Range 
         //if (__quest_state["Level 11 Manor"].mafia_internal_step < 4 && !have($item[Dramatic&trade; range]) && not in campground) stuff_to_buy.listAppend("Dramatic&trade; range");
 
@@ -172,7 +180,7 @@ void PathWereProfessorGenerateTasks(ChecklistEntry [int] task_entries, Checklist
         }
 
         if (professor_tips.count() > 0) {
-            tips_location.listAppend(ChecklistEntryMake("__monster government scientist", "", ChecklistSubentryMake("You are a Professor", professor_tips), priority));
+            tips_location.listAppend(ChecklistEntryMake("WereProfessor", "", ChecklistSubentryMake("You are a Professor", professor_tips), priority));
         }
     }
 }

--- a/Source/relay/TourGuide/Paths/WereProfessor.ash
+++ b/Source/relay/TourGuide/Paths/WereProfessor.ash
@@ -165,8 +165,7 @@ void PathWereProfessorGenerateTasks(ChecklistEntry [int] task_entries, Checklist
         if (!have($item[UV-resistant compass])) stuff_to_buy.listAppend("UV-resistant compass");
         if (!have($item[dinghy plans]) && !__misc_state["mysterious island available"]) stuff_to_buy.listAppend("dinghy plans");
         if (!have($item[dingy planks]) && !__misc_state["mysterious island available"]) stuff_to_buy.listAppend("dingy planks");
-        // TODO: Dramatic Range 
-        //if (__quest_state["Level 11 Manor"].mafia_internal_step < 4 && !have($item[Dramatic&trade; range]) && not in campground) stuff_to_buy.listAppend("Dramatic&trade; range");
+        if (__quest_state["Level 11 Manor"].mafia_internal_step < 4 && !have($item[Dramatic&trade; range]) && !get_property_boolean("hasRange")) stuff_to_buy.listAppend("Dramatic&trade; range");
 
         if (stuff_to_buy.count() > 0) {
             professor_tips.listAppend("Buy stuff before you become a Beast again: " + stuff_to_buy.listJoinComponents(", ", "or") + ".");

--- a/Source/relay/TourGuide/State.ash
+++ b/Source/relay/TourGuide/State.ash
@@ -527,7 +527,7 @@ void setUpState()
 	//wand
 	
 	boolean wand_of_nagamar_needed = true;
-	if (my_path().id == PATH_AVATAR_OF_BORIS || my_path().id == PATH_AVATAR_OF_JARLSBERG || my_path().id == PATH_AVATAR_OF_SNEAKY_PETE || my_path().id == PATH_BUGBEAR_INVASION || my_path().id == PATH_ZOMBIE_SLAYER || my_path().id == PATH_KOLHS || my_path().id == PATH_HEAVY_RAINS || my_path().id == PATH_ACTUALLY_ED_THE_UNDYING || my_path().id == PATH_COMMUNITY_SERVICE || my_path().id == PATH_THE_SOURCE || my_path().id == PATH_LICENSE_TO_ADVENTURE || my_path().id == PATH_POCKET_FAMILIARS || my_path().id == PATH_VAMPIRE || my_path().id == PATH_GREY_GOO || my_path().id == PATH_YOU_ROBOT || my_path().id == PATH_FALL_OF_THE_DINOSAURS || my_path().id == PATH_AVATAR_OF_SHADOWS_OVER_LOATHING)
+	if (my_path().id == PATH_AVATAR_OF_BORIS || my_path().id == PATH_AVATAR_OF_JARLSBERG || my_path().id == PATH_AVATAR_OF_SNEAKY_PETE || my_path().id == PATH_BUGBEAR_INVASION || my_path().id == PATH_ZOMBIE_SLAYER || my_path().id == PATH_KOLHS || my_path().id == PATH_HEAVY_RAINS || my_path().id == PATH_ACTUALLY_ED_THE_UNDYING || my_path().id == PATH_COMMUNITY_SERVICE || my_path().id == PATH_THE_SOURCE || my_path().id == PATH_LICENSE_TO_ADVENTURE || my_path().id == PATH_POCKET_FAMILIARS || my_path().id == PATH_VAMPIRE || my_path().id == PATH_GREY_GOO || my_path().id == PATH_YOU_ROBOT || my_path().id == PATH_FALL_OF_THE_DINOSAURS || my_path().id == PATH_AVATAR_OF_SHADOWS_OVER_LOATHING || my_path().id == PATH_WEREPROFESSOR)
 		wand_of_nagamar_needed = false;
 		
 	int ruby_w_needed = 1;

--- a/Source/relay/TourGuide/Support/KOLImage.ash
+++ b/Source/relay/TourGuide/Support/KOLImage.ash
@@ -271,6 +271,7 @@ static
         building_images["Avatar of Jarlsberg"] = KOLImageMake("images/otherimages/jarlsberg_avatar_f.gif", Vec2iMake(60,100), RectMake(0,6,59,96));
         building_images["Avatar of Boris"] = KOLImageMake("images/otherimages/boris_avatar_f.gif", Vec2iMake(60,100), RectMake(0,4,59,93));
         building_images["Zombie Master"] = KOLImageMake("images/otherimages/zombavatar_f.gif", Vec2iMake(60,100), RectMake(10,3,55,99));
+        building_images["WereProfessor"] = KOLImageMake("images/otherimages/wereprofavatar_f.gif", Vec2iMake(60,100), RectMake(9,7,50,98));
         building_images["Hourglass"] = KOLImageMake("images/itemimages/hourglass.gif", Vec2iMake(30,30));
 
         building_images["Nemesis Disco Bandit"] = KOLImageMake("images/adventureimages/newwave.gif", Vec2iMake(100,100));


### PR DESCRIPTION
Includes the following tiles:
- smashed scientific equipment locations tile (sorted by score; locations with more progress, quest locations and the latest location are placed higher):
![](https://i.imgur.com/YrPKyc1.png)
- tinkering tile (suggests research equipment, exoskeletons, and motion sensor if one does not have either Spring Shoes or Parka; only visible if at least one smashed equipment is available, I enabled it just to make a screenshot):
![](https://i.imgur.com/Pvxags4.png)
- Professor tips tile (reminder to reduce ML levels, equip research equipment, and buy stuff; pinned if there is anything in red):
![](https://i.imgur.com/Jazsq7f.png)

Also removes Wand of Nagamar tile (wand not needed) and Telescope tile (inaccessible).