### PR TITLE
august updates; kiwi + tearaway + darts and more!

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2015/Haunted Doghouse.ash
+++ b/Source/relay/TourGuide/Items of the Month/2015/Haunted Doghouse.ash
@@ -5,7 +5,7 @@ void IOTMHauntedDoghouseGenerateResource(ChecklistEntry [int] resource_entries)
         return;
     if ($item[tennis ball].available_amount() > 0 && in_ronin() && $item[tennis ball].item_is_usable())
     {
-        resource_entries.listAppend(ChecklistEntryMake("__item tennis ball", "", ChecklistSubentryMake(pluralise($item[tennis ball]), "", "Free run/banish."), 6).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Haunted doghouse banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item tennis ball", "", ChecklistSubentryMake(pluralise($item[tennis ball]), "", "Free run/banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Haunted doghouse banish"));
     }
     //I, um, hmm. I guess there's not much to say. Poor lonely file, nearly empty.
 }

--- a/Source/relay/TourGuide/Items of the Month/2016/Time-Spinner.ash
+++ b/Source/relay/TourGuide/Items of the Month/2016/Time-Spinner.ash
@@ -46,5 +46,5 @@ void IOTMTimeSpinnerGenerateResource(ChecklistEntry [int] resource_entries)
     }
     //Play a time prank - 1 minute, heart
     
-    resource_entries.listAppend(ChecklistEntryMake("Hourglass", "inv_use.php?whichitem=9104&pwd=" + my_hash(), ChecklistSubentryMake(pluralise(minutes_left, "Time-Spinner minute", "Time-Spinner minutes"), "", description), 5).ChecklistEntrySetIDTag("Time-spinner resource"));
+    resource_entries.listAppend(ChecklistEntryMake("__item Time-Spinner", "inv_use.php?whichitem=9104&pwd=" + my_hash(), ChecklistSubentryMake(pluralise(minutes_left, "Time-Spinner minute", "Time-Spinner minutes"), "", description), 5).ChecklistEntrySetIDTag("Time-spinner resource"));
 }

--- a/Source/relay/TourGuide/Items of the Month/2017/KGBriefcase.ash
+++ b/Source/relay/TourGuide/Items of the Month/2017/KGBriefcase.ash
@@ -16,7 +16,7 @@ void IOTMKGBriefcaseGenerateResource(ChecklistEntry [int] resource_entries)
 		    description.listAppend(HTMLGenerateSpanFont("Equip the briefcase first!", "red"));
             entry.url = "inventory.php?ftext=kremlin";
         }
-        resource_entries.listAppend(ChecklistEntryMake("__item Kremlin's Greatest Briefcase", entry.url, ChecklistSubentryMake(pluralise(3 - get_property_int("_kgbTranquilizerDartUses"), "briefcase dart", "briefcase darts"), "", description)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Kremlin Briefcase tranq dart banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item Kremlin's Greatest Briefcase", entry.url, ChecklistSubentryMake(pluralise(3 - get_property_int("_kgbTranquilizerDartUses"), "briefcase dart", "briefcase darts"), "", description),0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Kremlin Briefcase tranq dart banish"));
     }
     int clicks_remaining = clampi(22 - get_property_int("_kgbClicksUsed"), 0, 22);
     if (!mafiaIsPastRevision(18110))

--- a/Source/relay/TourGuide/Items of the Month/2017/New You.ash
+++ b/Source/relay/TourGuide/Items of the Month/2017/New You.ash
@@ -46,7 +46,7 @@ void IOTMNewYouGenerateResource(ChecklistEntry [int] resource_entries)
             }
             else if (it == lookupItem("Daily Affirmation: Be a Mind Master"))
             {
-                resource_entries.listAppend(ChecklistEntryMake("__item " + it, "", subentry).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("New you affirmation mind master banish"));
+                resource_entries.listAppend(ChecklistEntryMake("__item " + it, "", subentry, 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("New you affirmation mind master banish"));
             }
             else
 	            entry.subentries.listAppend(subentry);

--- a/Source/relay/TourGuide/Items of the Month/2017/Space Jellyfish.ash
+++ b/Source/relay/TourGuide/Items of the Month/2017/Space Jellyfish.ash
@@ -89,7 +89,7 @@ void IOTMSpaceJellyfishGenerateResource(ChecklistEntry [int] resource_entries)
         }
         
         if ($item[hot jelly].available_amount() > 0 && in_ronin())
-            resource_entries.listAppend(ChecklistEntryMake("__item hot jelly", "", ChecklistSubentryMake(pluralise($item[hot jelly]), "", "Chew for free run/banish.")).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Space jellyfish hot jelly banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item hot jelly", "", ChecklistSubentryMake(pluralise($item[hot jelly]), "", "Chew for free run/banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Space jellyfish hot jelly banish"));
         
         
         

--- a/Source/relay/TourGuide/Items of the Month/2019/May Saber.ash
+++ b/Source/relay/TourGuide/Items of the Month/2019/May Saber.ash
@@ -70,7 +70,7 @@ void IOTMMaySaberGenerateResource(ChecklistEntry [int] resource_entries)
             else
                 description.listAppend("Rollover runaway-like/banish");
 
-            resource_entries.listAppend(ChecklistEntryMake("__item Fourth of May Cosplay Saber", "inventory.php?which=2", ChecklistSubentryMake("(up to) " + uses_remaining.pluralise("force banish", "forces banishes"), "", description)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Fourth may saber force banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item Fourth of May Cosplay Saber", "inventory.php?which=2", ChecklistSubentryMake("(up to) " + uses_remaining.pluralise("force banish", "forces banishes"), "", description), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Fourth may saber force banish"));
         }
     }
 }

--- a/Source/relay/TourGuide/Items of the Month/2021/Emotion Chip.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Emotion Chip.ash
@@ -36,7 +36,7 @@ void IOTMEmotionChipGenerateResource(ChecklistEntry [int] resource_entries)
 			{
             emotions.listAppend(emotionHatred + " Hatreds left. 50-turn banish.");
 			
-			resource_entries.listAppend(ChecklistEntryMake("__skill feel hatred", "", ChecklistSubentryMake(pluralise(emotionHatred, "Feel Hatred", "Feels Hatreds"), "", "Free run, 50-turn banish.")).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Emotion chip feel hatred banish"));
+			resource_entries.listAppend(ChecklistEntryMake("__skill feel hatred", "", ChecklistSubentryMake(pluralise(emotionHatred, "Feel Hatred", "Feels Hatreds"), "", "Free run, 50-turn banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Emotion chip feel hatred banish"));
 			}
         int emotionLonely = clampi(3 - get_property_int("_feelLonelyUsed"), 0, 3);
         if (emotionLonely > 0 && $skill[Feel Lonely].skill_is_usable())

--- a/Source/relay/TourGuide/Items of the Month/2021/Familiar Scrapbook.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Familiar Scrapbook.ash
@@ -24,6 +24,6 @@ void IOTMFamiliarScrapbookGenerateResource(ChecklistEntry [int] resource_entries
 			description.listAppend(HTMLGenerateSpanFont("Equip the familiar scrapbook first", "red"));
 		
 		string url = invSearch("familiar scrapbook");
-		resource_entries.listAppend(ChecklistEntryMake("__item familiar scrapbook", url, ChecklistSubentryMake(familiar_scraps / 100 + " scrapbook banishes available", "", description)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Familiar scrapbook boring pictures banish"));
+		resource_entries.listAppend(ChecklistEntryMake("__item familiar scrapbook", url, ChecklistSubentryMake(familiar_scraps / 100 + " scrapbook banishes available", "", description), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Familiar scrapbook boring pictures banish"));
 	}
 }

--- a/Source/relay/TourGuide/Items of the Month/2021/Underground Fireworks Shop.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Underground Fireworks Shop.ash
@@ -40,7 +40,11 @@ void IOTMUndergroundFireworksShopGenerateTasks(ChecklistEntry [int] task_entries
 RegisterResourceGenerationFunction("IOTMUndergroundFireworksShopGenerateResource");
 void IOTMUndergroundFireworksShopGenerateResource(ChecklistEntry [int] resource_entries)
 {
-	if (my_path().id == PATH_G_LOVER) return; // none of this stuff has G in it
+	if (my_path().id == PATH_G_LOVER) return; // none of this stuff has G in it!
+
+	// Adding a way to get this to yank out the tile if you're in standard.
+	if (!lookupItem("fedora-mounted fountain").is_unrestricted()) return;
+
 	if (!get_property_boolean("_fireworksShopEquipmentBought") && available_amount($item[Clan VIP Lounge key]) > 0 && get_property("_fireworksShop").to_boolean() && my_path() != $path[Legacy of Loathing])
 		{
 			string [int] description;

--- a/Source/relay/TourGuide/Items of the Month/2021/Vampire Vintner.ash
+++ b/Source/relay/TourGuide/Items of the Month/2021/Vampire Vintner.ash
@@ -3,6 +3,9 @@ RegisterTaskGenerationFunction("IOTMVampireVintnerGenerateTasks");
 void IOTMVampireVintnerGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
 {
 	if (!__misc_state["in run"] || !lookupFamiliar("vampire vintner").familiar_is_usable()) return;
+
+	// For some reason, Vintner leaked into subsequent standards. Unfortunately, the wine isn't standard, so...
+	if (!lookupItem("1950 vampire vintner wine").is_unrestricted()) return;
 	
 	int vintnerFightsLeft = clampi(14 - get_property_int("vintnerCharge"), 0, 14);
 	int vintnerWineLevel = get_property_int("vintnerWineLevel");

--- a/Source/relay/TourGuide/Items of the Month/2022/Cosmic Bowling Ball.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Cosmic Bowling Ball.ash
@@ -53,7 +53,7 @@ void IOTMCosmicBowlingBallGenerateResource(ChecklistEntry [int] resource_entries
 		description.listAppend("Hit a strike! Knock the competition down a pin with your hole-y ball.");
 		description.listAppend("Give yourself an item/meat buff, gain stats in a zone, or banish for the next " + HTMLGenerateSpanOfClass(bowlingCooldown2, "r_bold") + " combats.");
 		
-		resource_entries.listAppend(ChecklistEntryMake("__item cosmic bowling ball", "", ChecklistSubentryMake("Cosmic bowling ball banish", "", "Has " + HTMLGenerateSpanOfClass(bowlingCooldown2, "r_bold") + " duration and cooldown.")).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Cosmic bowling ball banish"));
+		resource_entries.listAppend(ChecklistEntryMake("__item cosmic bowling ball", "", ChecklistSubentryMake("Bowl a Curveball with your Cosmic Bowling Ball", "", "Has " + HTMLGenerateSpanOfClass(bowlingCooldown2, "r_bold") + " duration and cooldown."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Cosmic bowling ball banish"));
 		resource_entries.listAppend(ChecklistEntryMake("__item cosmic bowling ball", url, ChecklistSubentryMake("Cosmic bowling ball use available", "", description)).ChecklistEntrySetCombinationTag("special").ChecklistEntrySetIDTag("Cosmic bowling ball skills"));
 	}
 	if (bowlingCooldown > -1)

--- a/Source/relay/TourGuide/Items of the Month/2023/Book of Facts.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Book of Facts.ash
@@ -11,11 +11,24 @@ void IOTMBookofFactsGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEn
 
 	// If they have an eagle, remind them they can eagle-banish to make it easier to find the habitat guys
 	string eagleString = lookupFamiliar("Patriotic Eagle").familiar_is_usable() ? "; remember, you can phylum-banish with your Patriotic Eagle to make it easier!" : "." ;
+	phylum eaglePhylumBanished = $phylum[none];
+
+    if (get_property("banishedPhyla") != "")
+        eaglePhylumBanished = get_property("banishedPhyla").split_string(":")[1].to_phylum();
 	
 	if (habitat_monster != $monster[none] && fights_left > 0) 
 	{
         description.listAppend("Neaaaar, faaaaaaar, wherever you spaaaaaaar, I believe that the heart does go onnnnn.");
 		description.listAppend("Appears as a wandering monster in any zone. Try a place with few competing monsters"+eagleString);
+
+		if (eaglePhylumBanished == habitat_monster.phylum) {
+			description.listAppend(HTMLGenerateSpanFont(`WARNING: {habitat_monster}'s phylum is banished!`, "red"));
+		}
+
+		if (habitat_monster.is_banished()) {
+			description.listAppend(HTMLGenerateSpanFont(`WARNING: {habitat_monster} is banished!`, "red"));
+		}
+
 		optional_task_entries.listAppend(ChecklistEntryMake("__monster " + habitat_monster, "", ChecklistSubentryMake("Fight " + pluralise(fights_left, "more non-native " + habitat_monster, "more non-native " + habitat_monster + "s"), "", description), -4));
     }
 

--- a/Source/relay/TourGuide/Items of the Month/2023/Book of Facts.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Book of Facts.ash
@@ -63,12 +63,17 @@ void IOTMBookofFactsGenerateResource(ChecklistEntry [int] resource_entries)
         BOFAdropsDescription.listAppend("" + BOFApocketwishes + " BOFA wishes available.");
     }
 
-	// Not going to remove this because I think it's valid right now but once mt_rand is 
-	//   properly exposed it would be good to hide this if the user is in a seed where 
-	//   they can't really access tatters...
-	int BOFAtatters = clampi(11 - get_property_int("_bookOfFactsTatters"), 0, 11);
-	if (get_property_int("_bookOfFactsTatters") < 11) {
-        BOFAdropsDescription.listAppend("" + BOFAtatters + " BOFA tatters available.");
+	// NOTE: Altering as of 2024 ELG change, as tatters are 40 turns vs the 30 of spring shoes. 
+	//   There is a remote chance in some future standard context tatters will be the best option
+	//   for a user with some odd IOTM configurations, which is why I didn't entirely extract
+	//   this, but it at least shouldn't be present if they own the candles or the shoes.
+
+	if (!__iotms_usable[lookupItem("spring shoes")] && $item[roman candelabra].available_amount() == 0) {
+		int BOFAtatters = clampi(11 - get_property_int("_bookOfFactsTatters"), 0, 11);
+		if (get_property_int("_bookOfFactsTatters") < 11) {
+			BOFAdropsDescription.listAppend("" + BOFAtatters + " BOFA tatters available.");
+		}	
 	}
+
 	resource_entries.listAppend(ChecklistEntryMake("__item book of facts", "", ChecklistSubentryMake(("Miscellaneous valuable BOFA drops"), "", BOFAdropsDescription), 8).ChecklistEntrySetIDTag("bofa tatters"));
 }

--- a/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Cursed Monkey Paw.ash
@@ -345,4 +345,17 @@ void IOTMCursedMonkeysPawGenerateResource(ChecklistEntry [int] resource_entries)
     if (monkeyWishesLeft > 0) {
         resource_entries.listAppend(ChecklistEntryMake(imageName, url, ChecklistSubentryMake(pluralise(monkeyWishesLeft, "monkey's paw wish", `monkey's paw wishes`), "", description)).ChecklistEntrySetIDTag("Monkey wishes"));
     }
+
+    // Banish combination tag for the monkey slap, if you've got it.
+    if (monkeyWishesLeft == 5) {
+        string [int] description;
+        string url;
+        url = "main.php";
+        description.listAppend("Turn-taking repeat-use banish. Lasts until you use it again!");
+        if ($item[cursed monkey paw].equipped_amount() == 0) {
+            description.listAppend("Equip your cursed monkey paw first.");
+            url = "inventory.php?ftext=cursed+monkey";
+        }
+        resource_entries.listAppend(ChecklistEntryMake("__skill monkey slap", "", ChecklistSubentryMake("Monkey Slap usable", "", description), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Cursed monkey paw banish"));
+    }
 }

--- a/Source/relay/TourGuide/Items of the Month/2023/Patriotic Eagle.ash
+++ b/Source/relay/TourGuide/Items of the Month/2023/Patriotic Eagle.ash
@@ -38,6 +38,17 @@ void IOTMPatrioticEagleGenerateTasks(ChecklistEntry [int] task_entries, Checklis
         if (fights_left > 0 && possible_appearance_locations.count() > 0)
             optional_task_entries.listAppend(entry);
     }
+    
+    // Extra nag from TES re: setting your global pledge.
+    string [int] description2;
+    
+    if (__misc_state["in run"] && ($effect[Citizen of a Zone].have_effect() == 0)) {
+        description2.listAppend("Haunted Kitchen: +100% init");
+        description2.listAppend("Haunted Library/Laundry: +30% item");
+        description2.listAppend("Batrat/Ninja Snowmen/Frat Battlefield: +50% meat");
+        task_entries.listAppend(ChecklistEntryMake("__familiar Patriotic Eagle", "familiar.php", ChecklistSubentryMake("Pledge to a zone!", description2), -5).ChecklistEntrySetIDTag("Patriotic Eagle familiar pledge reminder"));
+    }
+
 }
 	
 RegisterResourceGenerationFunction("IOTMPatrioticEagleGenerateResource");

--- a/Source/relay/TourGuide/Items of the Month/2024/Everfull Dart Holster.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Everfull Dart Holster.ash
@@ -1,0 +1,53 @@
+//Everfull Dart Holster via TES
+RegisterTaskGenerationFunction("IOTMEverfullDartsGenerateTasks");
+void IOTMEverfullDartsGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+	#if (__misc_state["in run"] && available_amount($item[everfull dart holster]) > 0 && my_path().id != PATH_COMMUNITY_SERVICE)
+	if (!__iotms_usable[$item[everfull dart holster]]) return;
+	{
+		string [int] description;
+		string url = "inventory.php?ftext=everfull+dart_holster";
+			
+			if ($effect[everything looks red].have_effect() == 0) 
+		{
+			int dartCooldown = 50;
+			if (get_property("everfullDartPerks").contains_text("You are less impressed by bullseyes")) {
+				dartCooldown -= 10;
+			}
+			if (get_property("everfullDartPerks").contains_text("Bullseyes do not impress you much")) {
+				dartCooldown -= 10;
+			}
+			description.listAppend(HTMLGenerateSpanFont("Shoot a bullseye! (" + dartCooldown + " ELR)", "red"));
+			if (lookupItem("everfull dart holster").equipped_amount() == 0)
+			{
+				description.listAppend(HTMLGenerateSpanFont("Equip the dart holster first.", "red"));
+			}
+			else description.listAppend(HTMLGenerateSpanFont("Dart holster equipped", "blue"));
+			task_entries.listAppend(ChecklistEntryMake("__item everfull dart holster", url, ChecklistSubentryMake("Everfull Darts free kill available!", "", description), -11));
+		}
+	}
+}
+
+RegisterResourceGenerationFunction("IOTMEverfullDartsGenerateResource");
+void IOTMEverfullDartsGenerateResource(ChecklistEntry [int] resource_entries)
+{
+	if (__misc_state["in run"] && available_amount($item[everfull dart holster]) > 0 && my_path().id != PATH_COMMUNITY_SERVICE)
+	{
+		int dartSkill = get_property_int("dartsThrown");
+		string [int] description;
+		string url = "inventory.php?ftext=everfull+dart_holster";
+			
+		if (dartSkill < 401) {
+			int dartsNeededForNextPerk = (floor(sqrt(dartSkill)+1) **2 - dartSkill);
+			description.listAppend("Current dart skill: " + dartSkill);
+			description.listAppend(HTMLGenerateSpanFont(dartsNeededForNextPerk, "blue") + " darts needed for next Perk");
+		
+			if (lookupItem("everfull dart holster").equipped_amount() == 0)
+			{
+				description.listAppend(HTMLGenerateSpanFont("Equip the dart holster first.", "red"));
+			}
+			else description.listAppend(HTMLGenerateSpanFont("Dart holster equipped", "blue"));
+			resource_entries.listAppend(ChecklistEntryMake("__item everfull dart holster", url, ChecklistSubentryMake("🍑🎯 Everfull Dart Holster charging", "", description), 11));
+		}
+	}
+}

--- a/Source/relay/TourGuide/Items of the Month/2024/Mayam Calendar.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Mayam Calendar.ash
@@ -21,6 +21,12 @@ void addToBothDescriptions(string [int] description1, string [int] description2,
 RegisterResourceGenerationFunction("IOTMMayamCalendarGenerateResource");
 void IOTMMayamCalendarGenerateResource(ChecklistEntry [int] resource_entries)
 {
+    // Adding this prior to the check if the user has stinkbombs.
+    if ($item[stuffed yam stinkbomb].available_amount() > 0 )
+    {
+        resource_entries.listAppend(ChecklistEntryMake("__item stuffed yam stinkbomb", "", ChecklistSubentryMake(pluralise($item[stuffed yam stinkbomb]), "", "Free run/banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Haunted doghouse banish"));
+    }
+
     if (available_amount($item[mayam calendar]) < 1)
         return;
 

--- a/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
@@ -21,7 +21,7 @@ void IOTMMiniKiwiGenerateResource(ChecklistEntry [int] resource_entries)
         description.listAppend('| Consider purchasing mini kiwi intoxicating spirits, for 3 kiwis.');
     }
 
-    if (!miniKiwiBikiniCount < 1 && get_property_int("zeppelinProtestors") < 80) {
+    if (miniKiwiBikiniCount < 1 && get_property_int("zeppelinProtestors") < 80) {
         description.listAppend('| Consider purchasing mini kiwi bikinis, for the Zeppelin sleaze test.');
     } 
 

--- a/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
@@ -6,25 +6,29 @@ void IOTMMiniKiwiGenerateResource(ChecklistEntry [int] resource_entries)
 
     // This familiar sucks. It's really bad. Still, fine to have a tile, I guess.
     int miniKiwiCount = $item[mini kiwi].available_amount();
-    int kiwiWeight = effective_familiar_weight($familiar[Mini Kiwi]) + weight_adjustment();
-    int kiwiModifier = $item[aviator goggles].available_amount() > 0 ? 0.75 : 0.50;
-    int kiwiChance = min(kiwiWeight * kiwiModifier,100);
+    float kiwiWeight = effective_familiar_weight($familiar[Mini Kiwi]) + weight_adjustment();
+    float kiwiModifier = $item[aviator goggles].available_amount() > 0 ? 0.75 : 0.50;
+
+    // Calculating the chance of a kiwi per fight; weight * your modifier
+    int kiwiChance = to_int(min(kiwiWeight * kiwiModifier,100.0));
     boolean kiwiSpiritsBought = get_property_boolean("_miniKiwiIntoxicatingSpiritsBought"); 
     int miniKiwiBikiniCount = $item[mini kiwi bikini].available_amount();
+
+    // Tile setup stuff
 	string [int] description;
-	string url = "familiar.php";
+	string url = "familiar.php"; // Could send to the kwiki mart, but don't care enough.
 	string header = pluralise(miniKiwiCount, "mini kiwi available", "mini kiwis available");
 
 	description.listAppend(`At {kiwiWeight} weight, you have a {kiwiChance}% chance of a mini kiwi each fight.`);
 
     if (!kiwiSpiritsBought) {
-        description.listAppend('| Consider purchasing mini kiwi intoxicating spirits, for 3 kiwis.');
+        description.listAppend('|*Consider purchasing mini kiwi intoxicating spirits, for 3 kiwis.');
     }
 
     if (miniKiwiBikiniCount < 1 && get_property_int("zeppelinProtestors") < 80) {
-        description.listAppend('| Consider purchasing mini kiwi bikinis, for the Zeppelin sleaze test.');
+        description.listAppend('|*Consider purchasing mini kiwi bikinis, for the Zeppelin sleaze test.');
     } 
 
-	resource_entries.listAppend(ChecklistEntryMake("__familiar mini kiwi", url, ChecklistSubentryMake(header, "", description), 0));
+	resource_entries.listAppend(ChecklistEntryMake("__familiar mini kiwi", url, ChecklistSubentryMake(header, "", description), 10));
 
 }

--- a/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
@@ -19,7 +19,7 @@ void IOTMMiniKiwiGenerateResource(ChecklistEntry [int] resource_entries)
 	string url = "familiar.php"; // Could send to the kwiki mart, but don't care enough.
 	string header = pluralise(miniKiwiCount, "mini kiwi available", "mini kiwis available");
 
-	description.listAppend(`At {kiwiWeight} weight, you have a {kiwiChance}% chance of a mini kiwi each fight.`);
+	description.listAppend(`At {to_int(kiwiWeight)} weight, you have a {kiwiChance}% chance of a mini kiwi each fight.`);
 
     if (!kiwiSpiritsBought) {
         description.listAppend('|*Consider purchasing mini kiwi intoxicating spirits, for 3 kiwis.');

--- a/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash
@@ -1,0 +1,30 @@
+// Mini-Kiwi
+RegisterResourceGenerationFunction("IOTMMiniKiwiGenerateResource");
+void IOTMMiniKiwiGenerateResource(ChecklistEntry [int] resource_entries)
+{
+	if (!lookupFamiliar("Mini Kiwi").familiar_is_usable()) return;
+
+    // This familiar sucks. It's really bad. Still, fine to have a tile, I guess.
+    int miniKiwiCount = $item[mini kiwi].available_amount();
+    int kiwiWeight = effective_familiar_weight($familiar[Mini Kiwi]) + weight_adjustment();
+    int kiwiModifier = $item[aviator goggles].available_amount() > 0 ? 0.75 : 0.50;
+    int kiwiChance = min(kiwiWeight * kiwiModifier,100);
+    boolean kiwiSpiritsBought = get_property_boolean("_miniKiwiIntoxicatingSpiritsBought"); 
+    int miniKiwiBikiniCount = $item[mini kiwi bikini].available_amount();
+	string [int] description;
+	string url = "familiar.php";
+	string header = pluralise(miniKiwiCount, "mini kiwi available", "mini kiwis available");
+
+	description.listAppend(`At {kiwiWeight} weight, you have a {kiwiChance}% chance of a mini kiwi each fight.`);
+
+    if (!kiwiSpiritsBought) {
+        description.listAppend('| Consider purchasing mini kiwi intoxicating spirits, for 3 kiwis.');
+    }
+
+    if (!miniKiwiBikiniCount < 1 && get_property_int("zeppelinProtestors") < 80) {
+        description.listAppend('| Consider purchasing mini kiwi bikinis, for the Zeppelin sleaze test.');
+    } 
+
+	resource_entries.listAppend(ChecklistEntryMake("__familiar mini kiwi", url, ChecklistSubentryMake(header, "", description), 0));
+
+}

--- a/Source/relay/TourGuide/Items of the Month/2024/Roman Candelabra.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Roman Candelabra.ash
@@ -26,12 +26,12 @@ void IOTMRomanCandelabraGenerateTasks(ChecklistEntry [int] task_entries, Checkli
         string [int] description;
         if (lookupItem("Roman Candelabra").equipped_amount() == 0)
         {
-            description.listAppend(HTMLGenerateSpanFont("Equip the Roman Candelabra first.", "red"));
+            description.listAppend(HTMLGenerateSpanFont("Equip the Roman Candelabra, for your purple ray.", "red"));
         }
         else
         {
-            description.listAppend(HTMLGenerateSpanFont("Candelbra equipped", "purple"));
+            description.listAppend(HTMLGenerateSpanFont("Candelbra equipped, blow your purple candle!", "purple"));
         }
-        task_entries.listAppend(ChecklistEntryMake("__item Roman Candelabra", url, ChecklistSubentryMake("Roman Candelabra chain ready!", "", description), -11));
+        task_entries.listAppend(ChecklistEntryMake("__item Roman Candelabra", url, ChecklistSubentryMake("Roman Candelabra monster chain ready", "", description), -11));
     }
 }

--- a/Source/relay/TourGuide/Items of the Month/2024/Spring Shoes.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Spring Shoes.ash
@@ -34,7 +34,7 @@ void IOTMSpringShoesGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEn
 
 void IOTMSpringShoesGenerateResource(ChecklistEntry [int] resource_entries)
 {
-	// Initialization. Do not generate iof you don't have spring shoes.
+	// Initialization. Do not generate if you don't have spring shoes.
 	if (!__iotms_usable[lookupItem("spring shoes")]) return;
 
 	string [int] banishDescription;
@@ -43,5 +43,5 @@ void IOTMSpringShoesGenerateResource(ChecklistEntry [int] resource_entries)
 	{
 		banishDescription.listAppend(HTMLGenerateSpanFont("Equip the spring shoes first.", "red"));
 	}
-	resource_entries.listAppend(ChecklistEntryMake("__skill spring shoes", "", ChecklistSubentryMake("Spring Kick", "", banishDescription)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Spring shoes spring kick banish"));
+	resource_entries.listAppend(ChecklistEntryMake("__skill spring shoes", "", ChecklistSubentryMake("Spring Kick", "", banishDescription), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Spring shoes spring kick banish"));
 }

--- a/Source/relay/TourGuide/Items of the Month/2024/Tearaway Pants.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Tearaway Pants.ash
@@ -1,0 +1,29 @@
+// Tearaway Pants
+RegisterResourceGenerationFunction("IOTMTearawayPantsGenerateTask");
+void IOTMTearawayPantsGenerateTask(ChecklistEntry [int] optional_task_entries)
+{
+    // Don't show the tile if you don't have the pants.
+	if (!!__iotms_usable[lookupItem("tearaway pants")]) return;
+
+    // Don't show the tile if you aren't a moxie class.
+    if (!($classes[disco bandit,accordion thief] contains my_class())) return;
+
+    // I can't believe I'm doing this. I have truly lost control of my life.
+    QuestState base_quest_state = __quest_state["Guild"];
+	if (base_quest_state.finished || !base_quest_state.startable || base_quest_state.mafia_internal_step == 2) return;
+
+    // Do you have the stupid pants equipped?
+    boolean havePantsEquipped = $slot[pants].equipped_item() == $item[tearaway pants];
+
+	string [int] description;
+
+    // If equipped, send user to the guild. If not, send them to the inventory.
+	string url = havePantsEquipped ? "guild.php" : "inventory.php?ftext=tearaway+pants";
+	string header = "Tear away your tearaway pants!";
+
+    if (havePantsEquipped) description.listAppend(`Visit the Department of Shadowy Arts and Crafts to unlock the guild!`);
+    if (!havePantsEquipped) description.listAppend(`Visit the Department of Shadowy Arts and Crafts with your pants equipped to unlock the guild!`);
+
+	optional_task_entries.listAppend(ChecklistEntryMake("__item tearaway pants", url, ChecklistSubentryMake(header, "", description), 0));
+
+}

--- a/Source/relay/TourGuide/Items of the Month/2024/Tearaway Pants.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Tearaway Pants.ash
@@ -3,7 +3,7 @@ RegisterResourceGenerationFunction("IOTMTearawayPantsGenerateTask");
 void IOTMTearawayPantsGenerateTask(ChecklistEntry [int] optional_task_entries)
 {
     // Don't show the tile if you don't have the pants.
-	if (!!__iotms_usable[lookupItem("tearaway pants")]) return;
+	if (!__iotms_usable[lookupItem("tearaway pants")]) return;
 
     // Don't show the tile if you aren't a moxie class.
     if (!($classes[disco bandit,accordion thief] contains my_class())) return;

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -151,3 +151,5 @@ import "relay/TourGuide/Items of the Month/2024/Everfull Dart Holster.ash";
 import "relay/TourGuide/Items of the Month/2024/Apriling Band Helmet.ash";
 import "relay/TourGuide/Items of the Month/2024/Mayam Calendar.ash";
 import "relay/TourGuide/Items of the Month/2024/Roman Candelabra.ash";
+import "relay/TourGuide/Items of the Month/2024/Mini Kiwi.ash";
+import "relay/TourGuide/Items of the Month/2024/Tearaway Pants.ash";

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -147,6 +147,7 @@ import "relay/TourGuide/Items of the Month/2023/Candy Cane Sword Cane.ash";
 // 2024
 import "relay/TourGuide/Items of the Month/2024/Chest Mimic.ash";
 import "relay/TourGuide/Items of the Month/2024/Spring Shoes.ash";
+import "relay/TourGuide/Items of the Month/2024/Everfull Dart Holster.ash";
 import "relay/TourGuide/Items of the Month/2024/Apriling Band Helmet.ash";
 import "relay/TourGuide/Items of the Month/2024/Mayam Calendar.ash";
 import "relay/TourGuide/Items of the Month/2024/Roman Candelabra.ash";

--- a/Source/relay/TourGuide/Paths/Avatar of West of Loathing.ash
+++ b/Source/relay/TourGuide/Paths/Avatar of West of Loathing.ash
@@ -113,7 +113,7 @@ void PathAvatarOfWestOfLoathingGenerateResource(ChecklistEntry [int] resource_en
             string title = pluralise(banish_count, "beancannon banish", "beancannon banishes");
             if (!in_ronin())
                 title = "Beancannon banishes";
-            resource_entries.listAppend(ChecklistEntryMake("__skill beancannon", url, ChecklistSubentryMake(title, "", description), 8).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("West Loathing path beancannon banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__skill beancannon", url, ChecklistSubentryMake(title, "", description), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("West Loathing path beancannon banish"));
         }
     }
     

--- a/Source/relay/TourGuide/Quests/Level 13.ash
+++ b/Source/relay/TourGuide/Quests/Level 13.ash
@@ -1134,6 +1134,8 @@ void QLevel13GenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [in
                 }
                 if (my_mp() < $skill[saucegeyser].mp_cost() * 4.0)
                     subentry.entries.listAppend(HTMLGenerateSpanFont("Restore some MP first.", "red"));
+                if (__iotms_usable[lookupItem("candy cane sword cane")])
+                    subentry.entries.listAppend("Also, consider using your Candy Cane Sword Cane's surprisingly sweet slash to cut the wall's HP by 75%!");
                 if (need_modifier_output)
                 {
                     subentry.modifiers.listAppend("mysticality");

--- a/Source/relay/TourGuide/Sections/Location Bar Popup.ash
+++ b/Source/relay/TourGuide/Sections/Location Bar Popup.ash
@@ -1003,7 +1003,33 @@ buffer generateLocationPopup(float bottom_coordinates, boolean location_bar_loca
             fl_entry_width_weight[fl_entries.count() - 1] = width_weight;
         }
         
-        
+        // ----------- NEW BIT FROM SCOTCH ABOUT BOFA -------------
+        if (true)
+        {
+            if ($skill[just the facts].have_skill()) {
+                string bofaText;
+                string bofaEffect = m.fact_type();
+                string factAppend;
+
+                // TODO: Bunch of stuff, this is a first implementation. Goals:
+                //   - Try to figure out a nicer way to format this.
+                //   - Filter out the "junk" BOFA results.
+                if (bofaEffect == "item") factAppend = HTMLGenerateSpanFont(m.item_fact().name,"red");
+                if (bofaEffect == "effect") factAppend = HTMLGenerateSpanFont(`{m.effect_fact().name} ({m.numeric_fact()})`,"blue");
+                bofaText = `{factAppend}`;
+
+                // I tried to put this a few places. First I tried in the stats
+                //   sidebar, then I tried under the name, then I tried as an
+                //   appended item. I ended up preferring having it generate in 
+                //   visibly in large zones with cutoff entries. I am pretty sure
+                //   the "best" solution is a more elegant way to add it to the
+                //   item list, but this initial implementation is good enough for
+                //   now, I think. 
+
+                fl_entries.listAppend(bofaText);
+                fl_entry_styles[fl_entries.count() - 1] = "text-align:left;font-size:0.8em";
+            }
+        }
         
         //FIXME handle canceling NC
         buffer rate_buffer;

--- a/Source/relay/TourGuide/Sets/Familiars.ash
+++ b/Source/relay/TourGuide/Sets/Familiars.ash
@@ -306,7 +306,7 @@ void SFamiliarsGenerateResource(ChecklistEntry [int] resource_entries)
 		if (__misc_state["have muscle class combat skill"])
         {
         	if (tag_with_banish_tag)
-            	resource_entries.listAppend(ChecklistEntryMake("__familiar nanorhino", "", ChecklistSubentryMake("Nanorhino Banish", "", description_banish)).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Nanorhino familiar banish"));
+            	resource_entries.listAppend(ChecklistEntryMake("__familiar nanorhino", "", ChecklistSubentryMake("Nanorhino Banish", "", description_banish), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Nanorhino familiar banish"));
             else
 				subentries.listAppend(ChecklistSubentryMake("Nanorhino Banish", "", description_banish));
         }

--- a/Source/relay/TourGuide/Sets/Misc Items.ash
+++ b/Source/relay/TourGuide/Sets/Misc Items.ash
@@ -660,7 +660,8 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
     }
     
     if (in_run) {
-        if ($item[tattered scrap of paper].available_amount() > 0 && __misc_state["free runs usable"] && $item[tattered scrap of paper].item_is_usable()) {
+        // As of the ELG change, tatters are worse than other options. Only show if the user doesn't have those options.
+        if ($item[tattered scrap of paper].available_amount() > 0 && __misc_state["free runs usable"] && $item[tattered scrap of paper].item_is_usable() && !__iotms_usable[lookupItem("spring shoes")] && !__iotms_usable[lookupItem("spring shoes")] && $item[roman candelabra].available_amount() == 0) {
             string [int] description;
             description.listAppend(($item[tattered scrap of paper].available_amount() / 2.0).roundForOutput(1) + " free runs.");
             if (in_bad_moon())

--- a/Source/relay/TourGuide/Sets/Misc Items.ash
+++ b/Source/relay/TourGuide/Sets/Misc Items.ash
@@ -163,7 +163,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
             if ($item[pantsgiving].equipped_amount() == 0)
                 tasks.listAppend("equip pantsgiving");
             tasks.listAppend("cast talk about politics");
-            resource_entries.listAppend(ChecklistEntryMake("__item pantsgiving", url, ChecklistSubentryMake(pluralise(banishes_available, "Pantsgiving banish", "Pantsgiving banishes"), "", tasks.listJoinComponents(", ").capitaliseFirstLetter() + ".")).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Pantsgiving banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item pantsgiving", url, ChecklistSubentryMake(pluralise(banishes_available, "Pantsgiving banish", "Pantsgiving banishes"), "", tasks.listJoinComponents(", ").capitaliseFirstLetter() + "."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Pantsgiving banish"));
             
         }
         
@@ -325,12 +325,12 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
     
     if (in_run) {
         if (7014.to_item().available_amount() > 0) //Louder than bomb
-            resource_entries.listAppend(ChecklistEntryMake("__item " + 7014.to_item().to_string(), "", ChecklistSubentryMake(pluralise(7014.to_item()), "", "Free run, 20-turn banish."), importance_level_item).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Louder than bomb banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item " + 7014.to_item().to_string(), "", ChecklistSubentryMake(pluralise(7014.to_item()), "", "Free run, 20-turn banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Louder than bomb banish"));
         if ($item[crystal skull].available_amount() > 0)
-            resource_entries.listAppend(ChecklistEntryMake("__item crystal skull", "", ChecklistSubentryMake(pluralise($item[crystal skull]), "", "Takes a turn, 20-turn banish."), importance_level_item).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Crystal skull banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item crystal skull", "", ChecklistSubentryMake(pluralise($item[crystal skull]), "", "Takes a turn, 20-turn banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Crystal skull banish"));
             
         if ($item[harold's bell].available_amount() > 0 && $item[harold's bell].item_is_usable())
-            resource_entries.listAppend(ChecklistEntryMake("__item harold's bell", "", ChecklistSubentryMake(pluralise($item[harold's bell]), "", "Takes a turn, 20-turn banish."), importance_level_item).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Harold's bell banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item harold's bell", "", ChecklistSubentryMake(pluralise($item[harold's bell]), "", "Takes a turn, 20-turn banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Harold's bell banish"));
         
         if ($item[lost key].available_amount() > 0 && $item[lost key].item_is_usable()){
             string [int] details;
@@ -448,7 +448,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
         }
     }
     if ($item[divine champagne popper].available_amount() > 0 && in_run) {
-        resource_entries.listAppend(ChecklistEntryMake("__item divine champagne popper", "", ChecklistSubentryMake(pluralise($item[divine champagne popper]), "", "Free run, 5-turn banish."), importance_level_unimportant_item).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Champagne popper banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item divine champagne popper", "", ChecklistSubentryMake(pluralise($item[divine champagne popper]), "", "Free run, 5-turn banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Champagne popper banish"));
     }
     if (__misc_state["need to level"]) {
         if ($item[dance card].available_amount() > 0 && my_primestat() == $stat[moxie] && in_ronin()) {
@@ -612,10 +612,10 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
         resource_entries.listAppend(ChecklistEntryMake("__item vitachoconutriment capsule", "inventory.php?ftext=vitachoconutriment+capsule", ChecklistSubentryMake(pluralise($item[vitachoconutriment capsule]), "", line), importance_level_unimportant_item).ChecklistEntrySetIDTag("Vitachoconutriment capsule"));
     }
     if (in_run && lookupItem("tryptophan dart").available_amount() > 0 && in_ronin() && lookupItem("tryptophan dart").item_is_usable()) {
-        resource_entries.listAppend(ChecklistEntryMake("__item tryptophan dart", "", ChecklistSubentryMake(pluralise(lookupItem("tryptophan dart")), "", "Free run/banish."), 6).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Tryptophan dart banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item tryptophan dart", "", ChecklistSubentryMake(pluralise(lookupItem("tryptophan dart")), "", "Non-free all-day banish."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Tryptophan dart banish"));
     }
     if (in_run && __misc_state["free runs usable"] && get_property_int("_humanMuskUses") < 3 && lookupItem("human musk").available_amount() > 0 && lookupItem("human musk") != $item[none]) {
-        resource_entries.listAppend(ChecklistEntryMake("__item human musk", "", ChecklistSubentryMake(MIN(lookupItem("human musk").available_amount(), 3 - get_property_int("_humanMuskUses")).pluralise("human musk", "human musks"), "", "Free run/banish. Consumes item."), 6).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Human musk banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item human musk", "", ChecklistSubentryMake(MIN(lookupItem("human musk").available_amount(), 3 - get_property_int("_humanMuskUses")).pluralise("human musk", "human musks"), "", "Free run/banish. Consumes item."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Human musk banish"));
     }
     
     if ($item[drum machine].available_amount() > 0 && in_run && (my_adventures() <= 1 || (availableDrunkenness() < 0 && availableDrunkenness() > -4 && my_adventures() >= 1)) && __quest_state["Level 11 Desert"].state_boolean["Desert Explored"] && $item[drum machine].item_is_usable()) {
@@ -629,7 +629,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
     
     if ($items[stinky cheese sword,stinky cheese diaper,stinky cheese wheel,stinky cheese eye,Staff of Queso Escusado].available_amount() > 0) {
         if (!get_property_boolean("_stinkyCheeseBanisherUsed"))
-            resource_entries.listAppend(ChecklistEntryMake("__item stinky cheese eye", "", ChecklistSubentryMake("Stinky cheese eye banish", "", "Free run.")).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Stinky cheese banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item stinky cheese eye", "", ChecklistSubentryMake("Stinky cheese eye banish", "", "Free run."), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Stinky cheese banish"));
         
         int stinky_cheese_charge = min(100, get_property_int("_stinkyCheeseCount"));
         string title;
@@ -831,7 +831,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
     
     if ($item[smoke grenade].available_amount() > 0 && in_run) {
         string description = "Turn-costing banish. (lasts 20 turns, no stats, no items, no meat)";
-        resource_entries.listAppend(ChecklistEntryMake("__item smoke grenade", "", ChecklistSubentryMake(pluralise($item[Smoke grenade]), "", description), importance_level_unimportant_item).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Smoke grenade banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item smoke grenade", "", ChecklistSubentryMake(pluralise($item[Smoke grenade]), "", description), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Smoke grenade banish"));
     }
     
     if ($item[pile of ashes].available_amount() > 0 && in_run) {
@@ -1063,7 +1063,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
             else
                 line += "30 MP";
             description.listAppend(line + ".");
-            resource_entries.listAppend(ChecklistEntryMake("__item V for Vivala mask", url, ChecklistSubentryMake("Creepy Grin usable", "", description), importance_level_item).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Vivala mask banish"));
+            resource_entries.listAppend(ChecklistEntryMake("__item V for Vivala mask", url, ChecklistSubentryMake("Creepy Grin usable", "", description), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Vivala mask banish"));
         }
         if (get_property_int("_vmaskAdv") < 10) {
             string url;
@@ -1238,7 +1238,7 @@ void SMiscItemsGenerateResource(ChecklistEntry [int] resource_entries)
         
     }
     if ($item[mafia middle finger ring].available_amount() > 0 && !get_property_boolean("_mafiaMiddleFingerRingUsed")) {
-        resource_entries.listAppend(ChecklistEntryMake("__item mafia middle finger ring", ($item[mafia middle finger ring].equipped_amount() == 0 ? $item[mafia middle finger ring].invSearch() : ""), ChecklistSubentryMake("Mafia middle finger ring banish/free run", "", "Once/day, 60 turn duration." + ($item[mafia middle finger ring].equipped_amount() == 0 ? " Equip first." : "")), 10).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Mafia middle finger ring banish"));
+        resource_entries.listAppend(ChecklistEntryMake("__item mafia middle finger ring", ($item[mafia middle finger ring].equipped_amount() == 0 ? $item[mafia middle finger ring].invSearch() : ""), ChecklistSubentryMake("Mafia middle finger ring banish/free run", "", "Once/day, 60 turn duration." + ($item[mafia middle finger ring].equipped_amount() == 0 ? " Equip first." : "")), 0).ChecklistEntrySetCombinationTag("banish").ChecklistEntrySetIDTag("Mafia middle finger ring banish"));
         
     }
 

--- a/Source/relay/TourGuide/Sets/Sneaks.ash
+++ b/Source/relay/TourGuide/Sets/Sneaks.ash
@@ -40,8 +40,9 @@ void SocialDistanceGenerator(ChecklistEntry [int] resource_entries)
         // usable if we have pill keeper plus free sneaks or spleen sneaks available
         final.sneakCondition = __iotms_usable[lookupItem("Eight Days a Week Pill Keeper")] && (freeSneakLeft + spleenSneaks > 0);
 
+        // never noticed I didn't explicitly say this was pillkeeper in the tile lol
         final.sneakCount = freeSneakLeft + spleenSneaks;
-        final.tileDescription = get_property_boolean("_freePillKeeperUsed") ? "" : `<b>1x free sneak, </b>`;
+        final.tileDescription = get_property_boolean("_freePillKeeperUsed") ? "" : `<b>1x PillKeeper free sneak, </b>`;
         final.tileDescription = final.tileDescription + `<b>{spleenSneaks}x sneaks</b> for 3 spleen each`;
         return final;
     }

--- a/Source/relay/TourGuide/Settings.ash
+++ b/Source/relay/TourGuide/Settings.ash
@@ -1,5 +1,5 @@
 //These settings are for development. Don't worry about editing them.
-string __version = "2.2.1"; // pushed to 2.2.1 on jill/leaves tiles
+string __version = "2.2.2"; // pushed to 2.2.1 on jill/leaves tiles
 
 //Path and name of the .js file. In case you change either.
 string __javascript = "TourGuide/TourGuide.js";

--- a/Source/relay/TourGuide/State.ash
+++ b/Source/relay/TourGuide/State.ash
@@ -338,7 +338,7 @@ void setUpState()
 		blank_outs_usable = false;
 	__misc_state["blank outs usable"] = free_runs_usable;
 	
-	
+	// TODO: reconfig this whole state thing re: free runs.
 	boolean free_runs_available = false;
 	if (familiar_is_usable($familiar[pair of stomping boots]) || ($skill[the ode to booze].skill_is_usable() && familiar_is_usable($familiar[Frumious Bandersnatch])))
 		free_runs_available = true;

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -138,8 +138,13 @@ void initialiseIOTMsUsable()
     if (lookupItem("cosmic bowling ball").available_amount() > 0 || get_property_int("_cosmicBowlingSkillsUsed") > 0) //Jan 2022
         // change to use tracking property if/when mafia adds one from coolitems.php
         __iotms_usable[lookupItem("cosmic bowling ball")] = true;
-    if (lookupItem("unbreakable umbrella").available_amount() > 0) //Mar 2021
+
+    if (lookupItem("unbreakable umbrella").available_amount() > 0) //Mar 2022  
         __iotms_usable[lookupItem("unbreakable umbrella")] = true;
+
+    if (lookupItem("Jurassic Parka").available_amount() > 0) // adding because of a strange issue w/ Sneaks.ash...
+        __iotms_usable[lookupItem("Jurassic Parka")] = true;
+
     if ($item[Clan VIP Lounge key].item_amount() > 0)
     {
     	//FIXME all

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -150,9 +150,24 @@ void initialiseIOTMsUsable()
     if (lookupItem("candy cane sword cane").available_amount() > 0) //Dec 2023
         __iotms_usable[lookupItem("candy cane sword cane")] = true;
 
-    if (lookupItem("spring shoes").available_amount() > 0) //Feb 2023
+    if (lookupItem("spring shoes").available_amount() > 0) //Feb 2024
         __iotms_usable[lookupItem("spring shoes")] = true;
         
+    if (lookupItem("everfull dart holster").available_amount() > 0) //Mar 2024
+        __iotms_usable[lookupItem("everfull dart holster")] = true;
+
+    if (lookupItem("apriling band helmet").available_amount() > 0) //Apr 2024
+        __iotms_usable[lookupItem("apriling band helmet")] = true;
+
+    if (lookupItem("mayam calendar").available_amount() > 0) //May 2024
+        __iotms_usable[lookupItem("mayam calendar")] = true;
+
+    if (lookupItem("roman candelabra").available_amount() > 0) //Jun 2024
+        __iotms_usable[lookupItem("roman candelabra")] = true;
+        
+    if (lookupItem("tearaway pants").available_amount() > 0) //Aug 2024
+        __iotms_usable[lookupItem("tearaway pants")] = true;
+
     //Can't use many things in G-Lover
     if (my_path().id == PATH_G_LOVER) //Path 33
     {

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -142,8 +142,8 @@ void initialiseIOTMsUsable()
     if (lookupItem("unbreakable umbrella").available_amount() > 0) //Mar 2022  
         __iotms_usable[lookupItem("unbreakable umbrella")] = true;
 
-    if (lookupItem("Jurassic Parka").available_amount() > 0) // adding because of a strange issue w/ Sneaks.ash...
-        __iotms_usable[lookupItem("Jurassic Parka")] = true;
+    if (available_amount($item[jurassic parka]) > 0) // adding because of a strange issue w/ Sneaks.ash...
+        __iotms_usable[$item[jurassic parka]] = true;
 
     if ($item[Clan VIP Lounge key].item_amount() > 0)
     {
@@ -305,8 +305,12 @@ void initialiseIOTMsUsable()
     replicaCheck("2002 Mr. Store Catalog"); # handled in own tile
     replicaCheck("August Scepter"); # handled in own tile
 
-    // Swap parka to false if you aren't torso aware.
-    if (!__misc_state["Torso aware"]) 
+    // Swap parka to false if you aren't torso aware. You cannot use the __misc_state
+    //   shortcuts here, because this comes before it in execution. That's a sad 
+    //   disadvantage of all our bundling, did not remotely realize state wasn't 
+    //   instantiated before this. That means the parka stuff hasn't shown up since
+    //   Legacy of Loathing lmao.
+    if (!$skill[12].have_skill()) 
     {
         __iotms_usable[lookupItem("Jurassic Parka")] = false;
     }


### PR DESCRIPTION
this is a PR to achieve most of what was noted in #231 after i finally had time to do a run this year. there are other bigger changes i'd like to do, but this PR is a reasonable version push to 2.2.2 with support for iotms up to and including the tearaway pants. big changes:

- incorporates TES darts tile from his darts branch. 
- adds a tile tracking # of mini kiwis at the very bottom of resources w/ small recs
- adds an optional task for moxie classes entreating them to use their tearaway pants for a free guild unlock

in addition to these 3 tiles, there is now a CCSC note in the level 13 quest brick at the wall of bones, all tatter mentions will not show for users w/ shoes or candles, standard availability has been fixed on clan fireworks & vintner tiles, and there is a warning preventing me specifically from doing the stupid-ass thing where you recall habitats on a dude while your eagle is phylum-banishing dudes. sigh. 

untested but i might do another H8U run before path ends on wednesday night, we shall see