### PR TITLE
Fix the division by 0 in Chest Mimic tile if the experience gain is zero

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2024/Chest Mimic.ash
+++ b/Source/relay/TourGuide/Items of the Month/2024/Chest Mimic.ash
@@ -9,7 +9,13 @@ void IOTMChestMimicGenerateResource(ChecklistEntry [int] resource_entries)
 	int famExperienceGain = numeric_modifier("familiar experience") + 1;
 	int chestExperience = ($familiar[chest mimic].experience);
 	int famExpNeededForNextEgg = (50 - (chestExperience % 50));
-    string fightsForNextEgg = pluralise(ceil(to_float(famExpNeededForNextEgg) / famExperienceGain), "fight", "fights");
+	string fightsForNextEgg;
+	if (famExperienceGain > 0) {
+		fightsForNextEgg = pluralise(ceil(to_float(famExpNeededForNextEgg) / famExperienceGain), "fight", "fights");
+	}
+	else {
+		fightsForNextEgg = "cannot get";
+	}
 	int mimicEggsLeft = clampi(11 - get_property_int("_mimicEggsObtained"), 0, 11);
 
 	string [int] description;


### PR DESCRIPTION
If the experience gain is equal to 0 (for example, by equipping a tiny consolation ribbon without having Testidunal Teachings permed), the Chest Mimic tile still tries to divide the experience needed for the next egg by the experience gain, generating a division by 0 error and crashing the script. 
Fixed so that if the experience gain is 0 or less, the tile says you cannot get the XP.