### PR TITLE
Remove autumn-aton panel in Standard

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2022/Autumnaton.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Autumnaton.ash
@@ -5,6 +5,7 @@ void IOTMAutumnatonGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEnt
 	# if (!__misc_state["in run"]) return; // Turned off because TES likes this tile to appear in aftercore
 	if (!get_property_boolean("hasAutumnaton")) return; // Don't show if they don't actually have Fall-E
 	if (my_path() == $path[Legacy of Loathing]) return; // Cannot use fall-e in LoL
+	if (my_path() == $path[Standard]) return; // Cannot use fall-e in Standard
     if (my_path().id == PATH_G_LOVER) return; // Cannot use fall-e in G-Lover 
 	if (in_bad_moon()) return; // Cannot use fall-e in Bad Moon
 


### PR DESCRIPTION
Removes autumn-aton tile in standard path. Note: does not remove the tile in the current standard challenge path (I'm trying to find a better solution than hard-coding it because then someone will need to change that whenever they release a new path)