### PR TITLE
Fix wrong method used to check florist availble

### DIFF
--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -64,7 +64,7 @@ void initialiseIOTMsUsable()
                 __iotms_usable[garden] = true;
         }
     }
-    if (florist_available() && $item[hand turkey outline].is_unrestricted()) //May 2013
+    if (get_property("floristFriarAvailable").to_boolean() && $item[hand turkey outline].is_unrestricted()) //May 2013
         //Order of the Green Thumb Order Form is not marked as out of standard.
         __iotms_usable[$item[Order of the Green Thumb Order Form]] = true; 
     if (get_property_boolean("sleazeAirportAlways") || get_property_boolean("_sleazeAirportToday")) //May 2014


### PR DESCRIPTION
This change to mafia means the function will, under the right circumstances, perform a http request every time it's called.

https://github.com/kolmafia/kolmafia/pull/3595